### PR TITLE
fix(听友FM): 优先动态匿名鉴权并修复解密日志变量

### DIFF
--- a/听书/听友FM.js
+++ b/听书/听友FM.js
@@ -1,6 +1,6 @@
 // @name 听友FM
 // @author OmniBox助手
-// @version 1.0.1
+// @version 1.0.3
 // @downloadURL https://gh-proxy.org/https://github.com/Silent1566/OmniBox-Spider/raw/refs/heads/main/听书/听友FM.js
 // @dependencies axios,cheerio,@noble/ciphers
 // notes:
@@ -159,6 +159,7 @@ async function encryptPayload(plainText) {
 }
 
 async function decryptPayloadHex(hex) {
+  const verboseApi = !!process.env.TINGYOU_VERBOSE_API;
   const raw = hexToBytes(hex);
   if (!raw || raw.length < 29) throw new Error("payload too short");
   const version = raw[0];
@@ -785,7 +786,8 @@ async function play(params, context) {
     let cookie = process.env.TINGYOU_COOKIE || process.env.TINGYOU_ANON_COOKIE || "";
     log("info", `play.headers.present ${j({ hasAuth: !!auth, hasCookie: !!cookie, albumId, chapterIdx, flag: flag || '' })}`);
 
-    if (!auth && !HARDCODED_TINGYOU_ANON_AUTH) {
+    // 播放优先尝试新的匿名鉴权，避免长期硬编码匿名凭证过期后一直卡死。
+    if (!process.env.TINGYOU_AUTH && !process.env.TINGYOU_ANON_AUTH) {
       try {
         const anon = await anonymousAuth();
         auth = anon.authToken || auth;
@@ -794,8 +796,8 @@ async function play(params, context) {
       } catch (anonErr) {
         log("error", `play.auth.anonymous.error message=${anonErr.message} stack=${anonErr.stack || ""}`);
       }
-    } else if (!auth && HARDCODED_TINGYOU_ANON_AUTH) {
-      log("info", `play.auth.anonymous.skip reason=useHardcodedFallback`);
+    } else {
+      log("info", `play.auth.anonymous.skip reason=useEnvCredentials`);
     }
 
     if (!auth) auth = HARDCODED_TINGYOU_ANON_AUTH || auth;


### PR DESCRIPTION
## 变更说明
- 同步 `main` 最新代码到 `openclaw`
- 修复 `听书/听友FM.js` 播放链路中的解密日志作用域错误
- 调整播放阶段鉴权优先级：优先尝试新的匿名鉴权，失败后再回退硬编码匿名凭证

## 具体修复
- `decryptPayloadHex()` 内补上 `verboseApi` 定义，避免 `play_token` 解包时抛出 `verboseApi is not defined`
- `play()` 中在未显式配置环境变量凭证时，优先执行 `anonymousAuth()` 获取新匿名凭证，避免旧硬编码匿名凭证过期后持续影响播放

## 验证
- `node --check 听书/听友FM.js`
- 当前已根据运行日志修复明确脚本错误，后续播放链仍可继续按新日志追调
