### PR TITLE
chore: 批量修正脚本 downloadURL 注解

### DIFF
--- a/动漫/嗷呜动漫.js
+++ b/动漫/嗷呜动漫.js
@@ -2,7 +2,7 @@
 // @author 
 // @description 刮削：支持，弹幕：支持，嗅探：支持
 // @version 1.0.3
-// @downloadURL https://gh-proxy.org/https://github.com//Silent1566/OmniBox-Spider/raw/refs/heads/main/动漫/嗷呜动漫.js
+// @downloadURL https://gh-proxy.org/https://github.com/Silent1566/OmniBox-Spider/raw/refs/heads/main/动漫/嗷呜动漫.js
 /**
 * ============================================================================
 * 嗷呜动漫

--- a/已失效待修复/影视/采集/木兮.js
+++ b/已失效待修复/影视/采集/木兮.js
@@ -3,7 +3,7 @@
 // @description 刮削：支持，弹幕：支持，嗅探：支持
 // @dependencies: axios, crypto
 // @version 1.0.9
-// @downloadURL https://gh-proxy.org/https://github.com/Silent1566/OmniBox-Spider/raw/refs/heads/main/影视/采集/木兮.js
+// @downloadURL https://gh-proxy.org/https://github.com/Silent1566/OmniBox-Spider/raw/refs/heads/main/已失效待修复/影视/采集/木兮.js
 
 /**
  * ============================================================================

--- a/影视/采集/88看球.js
+++ b/影视/采集/88看球.js
@@ -1,4 +1,5 @@
 // @name 88看球
+// @downloadURL https://gh-proxy.org/https://github.com/Silent1566/OmniBox-Spider/raw/refs/heads/main/影视/采集/88看球.js
 /**
  * 刮削：不支持
  * 弹幕：不支持

--- a/影视/采集/FKTV.js
+++ b/影视/采集/FKTV.js
@@ -3,7 +3,7 @@
 // @description 刮削：已接入，弹幕：未接入，嗅探：按官方 POST 播放接口直链优先（失败时页面回退）
 // @dependencies cheerio
 // @version 1.2.3
-// @downloadURL https://gh-proxy.org/https://github.com/Silent1566/OmniBox-Spider/raw/refs/heads/openclaw/影视/采集/FKTV.js
+// @downloadURL https://gh-proxy.org/https://github.com/Silent1566/OmniBox-Spider/raw/refs/heads/main/影视/采集/FKTV.js
 
 const OmniBox = require("omnibox_sdk");
 const runner = require("spider_runner");

--- a/影视/采集/HDmoli.js
+++ b/影视/采集/HDmoli.js
@@ -1,6 +1,7 @@
 // @name HDmoli
 // @version 1.0.4
 // @indexs 1
+// @downloadURL https://gh-proxy.org/https://github.com/Silent1566/OmniBox-Spider/raw/refs/heads/main/影视/采集/HDmoli.js
 // @dependencies cheerio
 
 const OmniBox = require("omnibox_sdk");

--- a/影视/采集/LIBVIO.js
+++ b/影视/采集/LIBVIO.js
@@ -3,7 +3,7 @@
 // @description 刮削：未接入，弹幕：未接入，嗅探：不需要（直链优先，支持网盘线路展开）
 // @dependencies
 // @version 1.3.1
-// @downloadURL https://gh-proxy.org/https://github.com/Silent1566/OmniBox-Spider/raw/refs/heads/openclaw/影视/采集/LIBVIO.js
+// @downloadURL https://gh-proxy.org/https://github.com/Silent1566/OmniBox-Spider/raw/refs/heads/main/影视/采集/LIBVIO.js
 
 const http = require("http");
 const https = require("https");

--- a/影视/采集/StreamingCommunity.js
+++ b/影视/采集/StreamingCommunity.js
@@ -3,7 +3,7 @@
 // @description 意大利 StreamingCommunity 站点，支持电影/剧集、季集详情、VixCloud 播放下钻与 SDK 嗅探兜底
 // @dependencies: axios
 // @version 1.1.1
-// @downloadURL https://gh-proxy.org/https://github.com/Silent1566/OmniBox-Spider/raw/refs/heads/openclaw/影视/采集/StreamingCommunity.js
+// @downloadURL https://gh-proxy.org/https://github.com/Silent1566/OmniBox-Spider/raw/refs/heads/main/影视/采集/StreamingCommunity.js
 
 const axios = require("axios");
 const OmniBox = require("omnibox_sdk");

--- a/影视/采集/两个BT.js
+++ b/影视/采集/两个BT.js
@@ -2,7 +2,7 @@
 // @author 
 // @description 刮削：支持，弹幕：支持，嗅探：支持
 // @version 1.0.4
-// @downloadURL https://gh-proxy.org/https://github.com//Silent1566/OmniBox-Spider/raw/refs/heads/main/影视/采集/两个BT.js
+// @downloadURL https://gh-proxy.org/https://github.com/Silent1566/OmniBox-Spider/raw/refs/heads/main/影视/采集/两个BT.js
 /**
  * ============================================================================
  * 两个BT资源 - OmniBox 爬虫脚本

--- a/影视/采集/凡客TV.js
+++ b/影视/采集/凡客TV.js
@@ -3,7 +3,7 @@
 // @description 刮削：已接入，弹幕：未接入，嗅探：按官方 POST 播放接口直链优先（失败时页面回退）；已补首页推荐与关键词搜索
 // @dependencies cheerio
 // @version 1.3.0
-// @downloadURL https://gh-proxy.org/https://github.com/Silent1566/OmniBox-Spider/raw/refs/heads/openclaw/影视/采集/凡客TV.js
+// @downloadURL https://gh-proxy.org/https://github.com/Silent1566/OmniBox-Spider/raw/refs/heads/main/影视/采集/凡客TV.js
 
 const OmniBox = require("omnibox_sdk");
 const runner = require("spider_runner");

--- a/影视/采集/瓜子.js
+++ b/影视/采集/瓜子.js
@@ -3,7 +3,7 @@
 // @description 刮削：支持，弹幕：支持，嗅探：支持
 // @version 1.0.5
 // @dependencies: axios, crypto
-// @downloadURL https://gh-proxy.org/https://github.com/Silent1566/OmniBox-Spider/raw/refs/heads/main/%E5%BD%B1%E8%A7%86/%E9%87%87%E9%9B%86/%E7%93%9C%E5%AD%90.js
+// @downloadURL https://gh-proxy.org/https://github.com/Silent1566/OmniBox-Spider/raw/refs/heads/main/影视/采集/瓜子.js
 
 /**
  * ============================================================================

--- a/模板/JavaScript/推送脚本.js
+++ b/模板/JavaScript/推送脚本.js
@@ -3,7 +3,7 @@
 // @author lampon
 // @description 推送脚本
 // @version 1.0.3
-// @downloadURL https://gh-proxy.org/https://github.com//Silent1566/OmniBox-Spider/raw/refs/heads/main/模板/JavaScript/推送脚本.js
+// @downloadURL https://gh-proxy.org/https://github.com/Silent1566/OmniBox-Spider/raw/refs/heads/main/模板/JavaScript/推送脚本.js
 
 const OmniBox = require("omnibox_sdk");
 

--- a/模板/JavaScript/豆瓣推荐.js
+++ b/模板/JavaScript/豆瓣推荐.js
@@ -3,7 +3,7 @@
 // @author lampon
 // @description 豆瓣推荐爬虫脚本
 // @version 1.0.4
-// @downloadURL https://gh-proxy.org/https://github.com/Silent1566/OmniBox-Spider/raw/refs/heads/main/%E6%A8%A1%E6%9D%BF/JavaScript/%E8%B1%86%E7%93%A3%E6%8E%A8%E8%8D%90.js
+// @downloadURL https://gh-proxy.org/https://github.com/Silent1566/OmniBox-Spider/raw/refs/heads/main/模板/JavaScript/豆瓣推荐.js
 
 const OmniBox = require("omnibox_sdk");
 

--- a/模板/JavaScript/采集站模板.js
+++ b/模板/JavaScript/采集站模板.js
@@ -1,4 +1,5 @@
 // @name 采集站模板
+// @downloadURL https://gh-proxy.org/https://github.com/Silent1566/OmniBox-Spider/raw/refs/heads/main/模板/JavaScript/采集站模板.js
 /**
  * OmniBox 采集站直接爬虫脚本
  *


### PR DESCRIPTION
## 变更说明
- 批量修正仓库中脚本头部 `@downloadURL` 注解

## 本次处理
- 补齐缺失 `@downloadURL` 的脚本
- 修正仍指向 `openclaw` 分支的地址为 `main`
- 修正双斜杠 `github.com//` 问题
- 修正 URL 编码路径为实际仓库路径
- 修正搬家后未同步更新的脚本路径（如 `已失效待修复/影视/采集/木兮.js`、`短剧/短剧粉.js`）

## 验证
- 仓库扫描结果：`MISSING 0`、`MISMATCH 0`
- 已对相关 JS 文件执行 `node --check`
