### PR TITLE
fix: 补齐 PR71 遗漏的版本号升级

### DIFF
--- a/动漫/嗷呜动漫.js
+++ b/动漫/嗷呜动漫.js
@@ -1,7 +1,7 @@
 // @name 嗷呜动漫
 // @author 
 // @description 刮削：支持，弹幕：支持，嗅探：支持
-// @version 1.0.3
+// @version 1.0.4
 // @downloadURL https://gh-proxy.org/https://github.com/Silent1566/OmniBox-Spider/raw/refs/heads/main/动漫/嗷呜动漫.js
 /**
 * ============================================================================

--- a/已失效待修复/影视/采集/木兮.js
+++ b/已失效待修复/影视/采集/木兮.js
@@ -2,7 +2,7 @@
 // @author https://github.com/hjdhnx/drpy-node/blob/main/spider/js_dr2/%E6%9C%A8%E5%85%AE%5B%E4%BC%98%5D.js
 // @description 刮削：支持，弹幕：支持，嗅探：支持
 // @dependencies: axios, crypto
-// @version 1.0.9
+// @version 1.0.10
 // @downloadURL https://gh-proxy.org/https://github.com/Silent1566/OmniBox-Spider/raw/refs/heads/main/已失效待修复/影视/采集/木兮.js
 
 /**

--- a/影视/采集/FKTV.js
+++ b/影视/采集/FKTV.js
@@ -2,7 +2,7 @@
 // @author 梦
 // @description 刮削：已接入，弹幕：未接入，嗅探：按官方 POST 播放接口直链优先（失败时页面回退）
 // @dependencies cheerio
-// @version 1.2.3
+// @version 1.2.4
 // @downloadURL https://gh-proxy.org/https://github.com/Silent1566/OmniBox-Spider/raw/refs/heads/main/影视/采集/FKTV.js
 
 const OmniBox = require("omnibox_sdk");

--- a/影视/采集/HDmoli.js
+++ b/影视/采集/HDmoli.js
@@ -1,5 +1,5 @@
 // @name HDmoli
-// @version 1.0.4
+// @version 1.0.5
 // @indexs 1
 // @downloadURL https://gh-proxy.org/https://github.com/Silent1566/OmniBox-Spider/raw/refs/heads/main/影视/采集/HDmoli.js
 // @dependencies cheerio

--- a/影视/采集/LIBVIO.js
+++ b/影视/采集/LIBVIO.js
@@ -2,7 +2,7 @@
 // @author 梦
 // @description 刮削：未接入，弹幕：未接入，嗅探：不需要（直链优先，支持网盘线路展开）
 // @dependencies
-// @version 1.3.1
+// @version 1.3.2
 // @downloadURL https://gh-proxy.org/https://github.com/Silent1566/OmniBox-Spider/raw/refs/heads/main/影视/采集/LIBVIO.js
 
 const http = require("http");

--- a/影视/采集/StreamingCommunity.js
+++ b/影视/采集/StreamingCommunity.js
@@ -2,7 +2,7 @@
 // @author 梦
 // @description 意大利 StreamingCommunity 站点，支持电影/剧集、季集详情、VixCloud 播放下钻与 SDK 嗅探兜底
 // @dependencies: axios
-// @version 1.1.1
+// @version 1.1.2
 // @downloadURL https://gh-proxy.org/https://github.com/Silent1566/OmniBox-Spider/raw/refs/heads/main/影视/采集/StreamingCommunity.js
 
 const axios = require("axios");

--- a/影视/采集/两个BT.js
+++ b/影视/采集/两个BT.js
@@ -1,7 +1,7 @@
 // @name 两个BT
 // @author 
 // @description 刮削：支持，弹幕：支持，嗅探：支持
-// @version 1.0.4
+// @version 1.0.5
 // @downloadURL https://gh-proxy.org/https://github.com/Silent1566/OmniBox-Spider/raw/refs/heads/main/影视/采集/两个BT.js
 /**
  * ============================================================================

--- a/影视/采集/凡客TV.js
+++ b/影视/采集/凡客TV.js
@@ -2,7 +2,7 @@
 // @author 梦
 // @description 刮削：已接入，弹幕：未接入，嗅探：按官方 POST 播放接口直链优先（失败时页面回退）；已补首页推荐与关键词搜索
 // @dependencies cheerio
-// @version 1.3.0
+// @version 1.3.1
 // @downloadURL https://gh-proxy.org/https://github.com/Silent1566/OmniBox-Spider/raw/refs/heads/main/影视/采集/凡客TV.js
 
 const OmniBox = require("omnibox_sdk");

--- a/模板/JavaScript/推送脚本.js
+++ b/模板/JavaScript/推送脚本.js
@@ -2,7 +2,7 @@
 // @push 1
 // @author lampon
 // @description 推送脚本
-// @version 1.0.3
+// @version 1.0.4
 // @downloadURL https://gh-proxy.org/https://github.com/Silent1566/OmniBox-Spider/raw/refs/heads/main/模板/JavaScript/推送脚本.js
 
 const OmniBox = require("omnibox_sdk");

--- a/模板/JavaScript/豆瓣推荐.js
+++ b/模板/JavaScript/豆瓣推荐.js
@@ -2,7 +2,7 @@
 // @indexs 1
 // @author lampon
 // @description 豆瓣推荐爬虫脚本
-// @version 1.0.4
+// @version 1.0.5
 // @downloadURL https://gh-proxy.org/https://github.com/Silent1566/OmniBox-Spider/raw/refs/heads/main/模板/JavaScript/豆瓣推荐.js
 
 const OmniBox = require("omnibox_sdk");


### PR DESCRIPTION
## 说明
- 补齐 PR #71（批量修正 `@downloadURL`）遗漏的版本号升级
- 本次仅对**原本已有 `@version`** 的脚本做 patch 级递增
- 不额外给原先没有 `@version` 的文件新增版本字段，避免把“补版本号”与“补规范化”混在同一个 PR

## 涉及文件
- 动漫/嗷呜动漫.js
- 已失效待修复/影视/采集/木兮.js
- 影视/采集/FKTV.js
- 影视/采集/HDmoli.js
- 影视/采集/LIBVIO.js
- 影视/采集/StreamingCommunity.js
- 影视/采集/两个BT.js
- 影视/采集/凡客TV.js
- 影视/采集/瓜子.js
- 模板/JavaScript/推送脚本.js
- 模板/JavaScript/豆瓣推荐.js
