### PR TITLE
fix: 同步盘搜类脚本 PanCheck 过滤逻辑

### DIFF
--- a/影视/网盘/盘搜.js
+++ b/影视/网盘/盘搜.js
@@ -1,7 +1,7 @@
 // @name 盘搜
 // @author 
 // @description 刮削：支持，弹幕：支持，嗅探：支持
-// @version 1.2.2
+// @version 1.2.3
 // @downloadURL https://gh-proxy.org/https://github.com/Silent1566/OmniBox-Spider/raw/refs/heads/main/影视/网盘/盘搜.js
 /**
  * OmniBox 网盘爬虫脚本
@@ -63,7 +63,7 @@ const PANCHECK_ENABLED = true;
 // PanCheck 选择的平台（可选，多个用逗号分隔）
 // 例如：baidu,aliyun,quark,115,tianyi,xunlei,123,mobile,uc
 // 如果不配置，则检测所有平台
-const PANCHECK_PLATFORMS = process.env.PANCHECK_PLATFORMS || "";
+const PANCHECK_PLATFORMS = process.env.PANCHECK_PLATFORMS || "quark,baidu,uc,pan123,tianyi,cmcc";
 
 // 网盘类型匹配配置: 使用分号分隔，例如 quark;uc
 const DRIVE_TYPE_CONFIG = (process.env.DRIVE_TYPE_CONFIG || "quark;uc").split(';').map((t) => t.trim()).filter(Boolean);
@@ -79,14 +79,45 @@ const PANSOU_CACHE_EX_SECONDS = Number(process.env.PANSOU_CACHE_EX_SECONDS || 43
 function inferDriveTypeFromSourceName(name = "") {
   const raw = String(name || "").toLowerCase();
   if (raw.includes("百度")) return "baidu";
-  if (raw.includes("天翼")) return "tianyi";
+  if (raw.includes("天翼")) return "tianyiyun";
   if (raw.includes("夸克")) return "quark";
   if (raw === "uc" || raw.includes("uc")) return "uc";
   if (raw.includes("115")) return "115";
   if (raw.includes("迅雷")) return "xunlei";
-  if (raw.includes("阿里")) return "ali";
-  if (raw.includes("123")) return "123pan";
+  if (raw.includes("阿里")) return "aliyun";
+  if (raw.includes("移动") || raw.includes("139") || raw.includes("cmcc")) return "cmcc";
+  if (raw.includes("123")) return "pan123";
   return raw;
+}
+
+function normalizePanCheckPlatform(input = "") {
+  const raw = String(input || "").trim().toLowerCase();
+  if (!raw) return "";
+  if (raw.includes("百度") || raw === "baidu") return "baidu";
+  if (raw.includes("天翼") || raw === "tianyi" || raw === "tianyiyun" || raw.includes("tianyi")) return "tianyiyun";
+  if (raw.includes("夸克") || raw === "quark") return "quark";
+  if (raw === "uc" || raw.includes("uc")) return "uc";
+  if (raw.includes("115")) return "115";
+  if (raw.includes("迅雷") || raw === "xunlei") return "xunlei";
+  if (raw.includes("阿里") || raw === "ali" || raw === "aliyun" || raw === "alipan" || raw === "aliyundrive" || raw.includes("aliyun") || raw.includes("alipan")) return "aliyun";
+  if (raw.includes("移动") || raw.includes("139") || raw === "cmcc" || raw === "mobile") return "cmcc";
+  if (raw === "123" || raw === "123pan" || raw === "pan123" || raw.includes("123pan") || raw.includes("pan123")) return "pan123";
+  return raw;
+}
+
+function inferDriveTypeFromShareURL(shareURL = "") {
+  const raw = String(shareURL || "").toLowerCase();
+  if (!raw) return "";
+  if (raw.includes("pan.quark.cn") || raw.includes("drive.quark.cn")) return "quark";
+  if (raw.includes("drive.uc.cn") || raw.includes("fast.uc.cn") || raw.includes("uc.cn")) return "uc";
+  if (raw.includes("pan.baidu.com")) return "baidu";
+  if (raw.includes("cloud.189.cn")) return "tianyiyun";
+  if (raw.includes("yun.139.com")) return "cmcc";
+  if (raw.includes("www.aliyundrive.com") || raw.includes("www.alipan.com") || raw.includes("aliyundrive.com") || raw.includes("alipan.com")) return "aliyun";
+  if (raw.includes("pan.xunlei.com")) return "xunlei";
+  if (raw.includes("115.com")) return "115";
+  if (raw.includes("123684.com") || raw.includes("123865.com") || raw.includes("123912.com") || raw.includes("123pan.com")) return "pan123";
+  return "";
 }
 
 function sortPlaySourcesByDriveOrder(playSources = []) {
@@ -109,15 +140,46 @@ function sortPlaySourcesByDriveOrder(playSources = []) {
 
 function inferDriveTypeFromResult(item = {}) {
   const rawType = String(item.type_id || item.type_name || item.vod_remarks || "").toLowerCase();
-  if (rawType.includes("aliyun") || rawType.includes("阿里")) return "ali";
-  if (rawType.includes("baidu") || rawType.includes("百度")) return "baidu";
-  if (rawType.includes("tianyi") || rawType.includes("天翼")) return "tianyi";
-  if (rawType.includes("quark") || rawType.includes("夸克")) return "quark";
-  if (rawType === "uc" || rawType.includes("uc")) return "uc";
-  if (rawType.includes("115")) return "115";
-  if (rawType.includes("xunlei") || rawType.includes("迅雷")) return "xunlei";
-  if (rawType.includes("123pan") || rawType === "123" || rawType.includes("123")) return "123pan";
-  return rawType;
+  return normalizePanCheckPlatform(rawType);
+}
+
+function getPanCheckSelectedPlatforms() {
+  return String(PANCHECK_PLATFORMS || "")
+    .split(",")
+    .map((p) => normalizePanCheckPlatform(p.trim()))
+    .filter(Boolean);
+}
+
+function splitLinksByPanCheckPlatforms(links = []) {
+  const allLinks = Array.isArray(links) ? links.filter(Boolean) : [];
+  const selectedPlatforms = getPanCheckSelectedPlatforms();
+
+  if (selectedPlatforms.length === 0) {
+    return {
+      selectedPlatforms: [],
+      linksToCheck: allLinks,
+      bypassLinks: [],
+    };
+  }
+
+  const selectedPlatformSet = new Set(selectedPlatforms);
+  const linksToCheck = [];
+  const bypassLinks = [];
+
+  for (const link of allLinks) {
+    const driveType = inferDriveTypeFromShareURL(link) || normalizePanCheckPlatform(OmniBox.getDriveInfoByShareURL(link)?.driveType || "");
+    if (selectedPlatformSet.has(driveType)) {
+      linksToCheck.push(link);
+    } else {
+      bypassLinks.push(link);
+    }
+  }
+
+  return {
+    selectedPlatforms,
+    linksToCheck,
+    bypassLinks,
+  };
 }
 
 function sortResultsByDriveOrder(results = []) {
@@ -263,34 +325,54 @@ async function setCachedJSON(key, value, exSeconds) {
  */
 async function checkLinksWithPanCheck(links) {
   if (!PANCHECK_ENABLED || !PANCHECK_API || links.length === 0) {
-    return new Set();
+    return {
+      invalidLinksSet: new Set(),
+      stats: null,
+    };
   }
 
   try {
-    OmniBox.log("info", `开始调用 PanCheck 检测链接，链接数量: ${links.length}`);
+    const { selectedPlatforms, linksToCheck, bypassLinks } = splitLinksByPanCheckPlatforms(links);
+    const detectDriveType = (link) => inferDriveTypeFromShareURL(link) || normalizePanCheckPlatform(OmniBox.getDriveInfoByShareURL(link)?.driveType || "") || "unknown";
+    const inputPlatformStats = {};
 
-    // 构建请求体
-    const requestBody = {
-      links: links,
-    };
-
-    // 如果配置了平台，添加到请求中
-    if (PANCHECK_PLATFORMS) {
-      const platforms = PANCHECK_PLATFORMS.split(",")
-        .map((p) => p.trim())
-        .filter((p) => p);
-      if (platforms.length > 0) {
-        requestBody.selected_platforms = platforms;
-      }
+    for (const link of links) {
+      const driveType = detectDriveType(link);
+      inputPlatformStats[driveType] = (inputPlatformStats[driveType] || 0) + 1;
     }
 
-    // 构建 URL
-    const apiUrl = PANCHECK_API.replace(/\/$/, ""); // 移除末尾的斜杠
-    const checkURL = `${apiUrl}/api/v1/links/check`;
+    if (linksToCheck.length === 0) {
+      OmniBox.log("info", `PanCheck 跳过: 未命中待校验平台, 跳过链接数量: ${bypassLinks.length}`);
+      return {
+        invalidLinksSet: new Set(),
+        stats: {
+          selectedPlatforms,
+          inputPlatformStats,
+          checkedPlatformStats: {},
+          invalidPlatformStats: {},
+          validPlatformStats: {},
+          bypassPlatformStats: inputPlatformStats,
+          totalInput: links.length,
+          totalChecked: 0,
+          totalInvalid: 0,
+          totalValid: 0,
+          totalBypass: bypassLinks.length,
+          totalOutput: links.length,
+        },
+      };
+    }
 
+    OmniBox.log("info", `开始调用 PanCheck 检测链接, 总链接: ${links.length}, 待校验: ${linksToCheck.length}, 跳过: ${bypassLinks.length}, 平台: ${selectedPlatforms.join(",") || "全部"}`);
+
+    const requestBody = { links: linksToCheck };
+    if (selectedPlatforms.length > 0) {
+      requestBody.selected_platforms = selectedPlatforms;
+    }
+
+    const apiUrl = PANCHECK_API.replace(/\/$/, "");
+    const checkURL = `${apiUrl}/api/v1/links/check`;
     OmniBox.log("info", `PanCheck API URL: ${checkURL}`);
 
-    // 发送请求
     const response = await OmniBox.request(checkURL, {
       method: "POST",
       headers: {
@@ -302,28 +384,72 @@ async function checkLinksWithPanCheck(links) {
 
     if (response.statusCode !== 200) {
       OmniBox.log("warn", `PanCheck API 响应错误: ${response.statusCode}, 响应体: ${response.body?.substring(0, 500) || ""}`);
-      return new Set(); // 检测失败，不过滤任何链接
+      return {
+        invalidLinksSet: new Set(),
+        stats: null,
+      };
     }
 
     if (!response.body) {
       OmniBox.log("warn", "PanCheck API 返回空响应");
-      return new Set();
+      return {
+        invalidLinksSet: new Set(),
+        stats: null,
+      };
     }
 
     const data = JSON.parse(response.body);
     const invalidLinks = data.invalid_links || [];
+    const validLinks = data.valid_links || [];
+    const invalidLinksSet = new Set(invalidLinks);
+    const checkedPlatformStats = {};
+    const invalidPlatformStats = {};
+    const validPlatformStats = {};
+    const bypassPlatformStats = {};
 
-    OmniBox.log("info", `PanCheck 检测完成，无效链接数量: ${invalidLinks.length}`);
+    for (const link of linksToCheck) {
+      const driveType = detectDriveType(link);
+      checkedPlatformStats[driveType] = (checkedPlatformStats[driveType] || 0) + 1;
+      if (invalidLinksSet.has(link)) {
+        invalidPlatformStats[driveType] = (invalidPlatformStats[driveType] || 0) + 1;
+      } else {
+        validPlatformStats[driveType] = (validPlatformStats[driveType] || 0) + 1;
+      }
+    }
 
-    // 返回无效链接集合
-    return new Set(invalidLinks);
+    for (const link of bypassLinks) {
+      const driveType = detectDriveType(link);
+      bypassPlatformStats[driveType] = (bypassPlatformStats[driveType] || 0) + 1;
+    }
+
+    OmniBox.log("info", `PanCheck 检测完成,有效链接: ${validLinks.length}, 无效链接: ${invalidLinks.length}, 未校验直出: ${bypassLinks.length}`);
+
+    return {
+      invalidLinksSet,
+      stats: {
+        selectedPlatforms,
+        inputPlatformStats,
+        checkedPlatformStats,
+        invalidPlatformStats,
+        validPlatformStats,
+        bypassPlatformStats,
+        totalInput: links.length,
+        totalChecked: linksToCheck.length,
+        totalInvalid: invalidLinks.length,
+        totalValid: validLinks.length,
+        totalBypass: bypassLinks.length,
+        totalOutput: (links.length - invalidLinks.length),
+      },
+    };
   } catch (error) {
     OmniBox.log("warn", `PanCheck 链接检测失败: ${error.message}`);
     if (error.stack) {
       OmniBox.log("warn", `错误堆栈: ${error.stack}`);
     }
-    // 检测失败，不过滤任何链接
-    return new Set();
+    return {
+      invalidLinksSet: new Set(),
+      stats: null,
+    };
   }
 }
 
@@ -771,7 +897,11 @@ async function search(params) {
 
         if (links.length > 0) {
           // 调用 PanCheck 检测链接
-          const invalidLinksSet = await checkLinksWithPanCheck(links);
+          const { invalidLinksSet, stats } = await checkLinksWithPanCheck(links);
+          if (stats) {
+            OmniBox.log("info", `PanCheck 分平台统计(盘搜搜索): 输入=${JSON.stringify(stats.inputPlatformStats)}, 校验=${JSON.stringify(stats.checkedPlatformStats)}, 过滤=${JSON.stringify(stats.invalidPlatformStats)}, 剩余=${JSON.stringify(stats.validPlatformStats)}, 跳过=${JSON.stringify(stats.bypassPlatformStats)}`);
+            OmniBox.log("info", `PanCheck 总统计(盘搜搜索): 总输入=${stats.totalInput}, 总校验=${stats.totalChecked}, 总过滤=${stats.totalInvalid}, 总剩余=${stats.totalOutput}, 其中直出=${stats.totalBypass}`);
+          }
 
           if (invalidLinksSet.size > 0) {
             OmniBox.log("info", `检测到无效链接数量: ${invalidLinksSet.size}`);

--- a/影视/网盘/聚盘搜索.js
+++ b/影视/网盘/聚盘搜索.js
@@ -2,7 +2,7 @@
 // @author 梦
 // @description 站点搜索 + 网盘资源解析（夸克/百度/迅雷等），支持网盘目录展开、刮削、弹幕、观看记录
 // @dependencies: axios
-// @version 1.0.0
+// @version 1.0.1
 // @downloadURL https://gh-proxy.org/https://github.com/Silent1566/OmniBox-Spider/raw/refs/heads/main/影视/网盘/聚盘搜索.js
 
 
@@ -23,7 +23,7 @@ const SEARCH_POLL_INTERVAL_MS = 900;
 // 用法：在搜索结果落地前，先把全部 share_link 汇总成一批，调用一次 pancheck，再过滤无效链接
 const PANCHECK_API = text(process.env.PANCHECK_API || "");
 const PANCHECK_ENABLED = text(process.env.PANCHECK_ENABLED || (PANCHECK_API ? "1" : "0")) === "1";
-const PANCHECK_PLATFORMS = text(process.env.PANCHECK_PLATFORMS || ""); // 例：quark,baidu,xunlei
+const PANCHECK_PLATFORMS = text(process.env.PANCHECK_PLATFORMS || "quark,baidu,uc,pan123,tianyi,cmcc"); // 例：quark,baidu,xunlei
 
 // 网盘排序配置（必须置于顶部配置区，便于统一管理）
 const DRIVE_ORDER_DEFAULT = "百度网盘,天翼网盘,夸克网盘,UC网盘,115网盘,迅雷网盘,阿里网盘";
@@ -99,20 +99,50 @@ async function apiGet(path, params = {}) {
  */
 async function checkLinksWithPanCheck(links) {
   if (!PANCHECK_ENABLED || !PANCHECK_API || !Array.isArray(links) || links.length === 0) {
-    return new Set();
+    return {
+      invalidLinksSet: new Set(),
+      stats: null,
+    };
   }
 
   try {
-    const body = { links };
-    if (PANCHECK_PLATFORMS) {
-      const platforms = PANCHECK_PLATFORMS.split(",").map((x) => x.trim()).filter(Boolean);
-      if (platforms.length) body.selected_platforms = platforms;
+    const { selectedPlatforms, linksToCheck, bypassLinks } = splitLinksByPanCheckPlatforms(links);
+    const detectDriveType = (link) => normalizeDriveType("", link) || "unknown";
+    const inputPlatformStats = {};
+
+    for (const link of links) {
+      const driveType = detectDriveType(link);
+      inputPlatformStats[driveType] = (inputPlatformStats[driveType] || 0) + 1;
     }
+
+    if (linksToCheck.length === 0) {
+      await OmniBox.log("info", `[dyuzi] PanCheck 跳过: 未命中待校验平台, 跳过链接数量=${bypassLinks.length}`);
+      return {
+        invalidLinksSet: new Set(),
+        stats: {
+          selectedPlatforms,
+          inputPlatformStats,
+          checkedPlatformStats: {},
+          invalidPlatformStats: {},
+          validPlatformStats: {},
+          bypassPlatformStats: inputPlatformStats,
+          totalInput: links.length,
+          totalChecked: 0,
+          totalInvalid: 0,
+          totalValid: 0,
+          totalBypass: bypassLinks.length,
+          totalOutput: links.length,
+        },
+      };
+    }
+
+    const body = { links: linksToCheck };
+    if (selectedPlatforms.length) body.selected_platforms = selectedPlatforms;
 
     const apiUrl = PANCHECK_API.replace(/\/$/, "");
     const checkURL = `${apiUrl}/api/v1/links/check`;
 
-    await OmniBox.log("info", `[dyuzi] PanCheck 开始，链接数=${links.length}, url=${checkURL}`);
+    await OmniBox.log("info", `[dyuzi] PanCheck 开始，总链接=${links.length}, 待校验=${linksToCheck.length}, 跳过=${bypassLinks.length}, 平台=${selectedPlatforms.join(",") || "全部"}, url=${checkURL}`);
     const res = await OmniBox.request(checkURL, {
       method: "POST",
       headers: {
@@ -124,16 +154,60 @@ async function checkLinksWithPanCheck(links) {
 
     if (res.statusCode !== 200) {
       await OmniBox.log("warn", `[dyuzi] PanCheck 状态码异常 status=${res.statusCode}`);
-      return new Set();
+      return {
+        invalidLinksSet: new Set(),
+        stats: null,
+      };
     }
 
     const data = safeJson(res.body, {});
     const invalid = Array.isArray(data.invalid_links) ? data.invalid_links : [];
-    await OmniBox.log("info", `[dyuzi] PanCheck 完成，无效链接数=${invalid.length}`);
-    return new Set(invalid.map((x) => String(x)));
+    const valid = Array.isArray(data.valid_links) ? data.valid_links : [];
+    const invalidLinksSet = new Set(invalid.map((x) => String(x)));
+    const checkedPlatformStats = {};
+    const invalidPlatformStats = {};
+    const validPlatformStats = {};
+    const bypassPlatformStats = {};
+
+    for (const link of linksToCheck) {
+      const driveType = detectDriveType(link);
+      checkedPlatformStats[driveType] = (checkedPlatformStats[driveType] || 0) + 1;
+      if (invalidLinksSet.has(String(link))) {
+        invalidPlatformStats[driveType] = (invalidPlatformStats[driveType] || 0) + 1;
+      } else {
+        validPlatformStats[driveType] = (validPlatformStats[driveType] || 0) + 1;
+      }
+    }
+
+    for (const link of bypassLinks) {
+      const driveType = detectDriveType(link);
+      bypassPlatformStats[driveType] = (bypassPlatformStats[driveType] || 0) + 1;
+    }
+
+    await OmniBox.log("info", `[dyuzi] PanCheck 完成，有效链接数=${valid.length}, 无效链接数=${invalid.length}, 未校验直出=${bypassLinks.length}`);
+    return {
+      invalidLinksSet,
+      stats: {
+        selectedPlatforms,
+        inputPlatformStats,
+        checkedPlatformStats,
+        invalidPlatformStats,
+        validPlatformStats,
+        bypassPlatformStats,
+        totalInput: links.length,
+        totalChecked: linksToCheck.length,
+        totalInvalid: invalid.length,
+        totalValid: valid.length,
+        totalBypass: bypassLinks.length,
+        totalOutput: (links.length - invalid.length),
+      },
+    };
   } catch (e) {
     await OmniBox.log("warn", `[dyuzi] PanCheck 调用失败: ${e.message}`);
-    return new Set();
+    return {
+      invalidLinksSet: new Set(),
+      stats: null,
+    };
   }
 }
 
@@ -240,11 +314,14 @@ async function resolveResource(inputId) {
 function driveFromLink(link) {
   const u = text(link).toLowerCase();
   if (!u) return "";
-  if (u.includes("pan.quark.cn")) return "quark";
+  if (u.includes("pan.quark.cn") || u.includes("drive.quark.cn")) return "quark";
   if (u.includes("pan.baidu.com")) return "baidu";
   if (u.includes("pan.xunlei.com")) return "xunlei";
-  if (u.includes("drive.uc.cn") || u.includes("uc.cn")) return "uc";
-  if (u.includes("aliyundrive.com")) return "aliyun";
+  if (u.includes("drive.uc.cn") || u.includes("fast.uc.cn") || u.includes("uc.cn")) return "uc";
+  if (u.includes("aliyundrive.com") || u.includes("alipan.com")) return "aliyun";
+  if (u.includes("cloud.189.cn")) return "tianyiyun";
+  if (u.includes("yun.139.com")) return "cmcc";
+  if (u.includes("123684.com") || u.includes("123865.com") || u.includes("123912.com") || u.includes("123pan.com")) return "pan123";
   return "";
 }
 
@@ -254,13 +331,15 @@ function driveAliasToCode(input) {
 
   const map = {
     "百度网盘": "baidu", "baidu": "baidu",
-    "天翼网盘": "tianyiyun", "tianyiyun": "tianyiyun",
+    "天翼网盘": "tianyiyun", "天翼": "tianyiyun", "tianyi": "tianyiyun", "tianyiyun": "tianyiyun",
     "夸克网盘": "quark", "quark": "quark",
     "uc网盘": "uc", "uc": "uc",
     "115网盘": "115", "115": "115",
     "迅雷网盘": "xunlei", "xunlei": "xunlei",
     "阿里网盘": "aliyun", "阿里云盘": "aliyun",
-    "aliyun": "aliyun", "aliyundrive": "aliyun"
+    "aliyun": "aliyun", "aliyundrive": "aliyun", "ali": "aliyun", "alipan": "aliyun",
+    "移动云盘": "cmcc", "移动": "cmcc", "cmcc": "cmcc", "mobile": "cmcc", "139": "cmcc",
+    "123网盘": "pan123", "123pan": "pan123", "pan123": "pan123", "123": "pan123"
   };
 
   return map[input] || map[v] || v;
@@ -291,6 +370,45 @@ function normalizeDriveType(driveTypeRaw, link) {
   const d = driveAliasToCode(driveTypeRaw);
   if (d) return d;
   return driveAliasToCode(driveFromLink(link || ""));
+}
+
+function getPanCheckSelectedPlatforms() {
+  return text(PANCHECK_PLATFORMS)
+    .split(",")
+    .map((x) => driveAliasToCode(x))
+    .filter(Boolean);
+}
+
+function splitLinksByPanCheckPlatforms(links = []) {
+  const allLinks = Array.isArray(links) ? links.filter(Boolean) : [];
+  const selectedPlatforms = getPanCheckSelectedPlatforms();
+
+  if (selectedPlatforms.length === 0) {
+    return {
+      selectedPlatforms: [],
+      linksToCheck: allLinks,
+      bypassLinks: [],
+    };
+  }
+
+  const selectedPlatformSet = new Set(selectedPlatforms);
+  const linksToCheck = [];
+  const bypassLinks = [];
+
+  for (const link of allLinks) {
+    const driveType = normalizeDriveType("", link);
+    if (selectedPlatformSet.has(driveType)) {
+      linksToCheck.push(link);
+    } else {
+      bypassLinks.push(link);
+    }
+  }
+
+  return {
+    selectedPlatforms,
+    linksToCheck,
+    bypassLinks,
+  };
 }
 
 /**
@@ -522,9 +640,13 @@ async function search(params, context) {
       const links = extractLinksFromItems(items);
       await OmniBox.log("info", `[search] PanCheck 预校验链接数=${links.length}`);
       if (links.length > 0) {
-        const invalidSet = await checkLinksWithPanCheck(links);
+        const { invalidLinksSet, stats } = await checkLinksWithPanCheck(links);
         const before = items.length;
-        items = filterInvalidItems(items, invalidSet);
+        items = filterInvalidItems(items, invalidLinksSet);
+        if (stats) {
+          await OmniBox.log("info", `[search] PanCheck 分平台统计: 输入=${JSON.stringify(stats.inputPlatformStats)}, 校验=${JSON.stringify(stats.checkedPlatformStats)}, 过滤=${JSON.stringify(stats.invalidPlatformStats)}, 剩余=${JSON.stringify(stats.validPlatformStats)}, 跳过=${JSON.stringify(stats.bypassPlatformStats)}`);
+          await OmniBox.log("info", `[search] PanCheck 总统计: 总输入=${stats.totalInput}, 总校验=${stats.totalChecked}, 总过滤=${stats.totalInvalid}, 总剩余=${stats.totalOutput}, 其中直出=${stats.totalBypass}`);
+        }
         await OmniBox.log("info", `[search] PanCheck 过滤完成 before=${before}, after=${items.length}, removed=${before - items.length}`);
       }
     } catch (e) {
@@ -703,9 +825,13 @@ async function detail(params, context) {
       try {
         const links = candidates.map((c) => text(c.share_link || c.link || "")).filter(Boolean);
         await OmniBox.log("info", `[detail] PanCheck 开始，链接数=${links.length}`);
-        const invalidSet = await checkLinksWithPanCheck(links);
+        const { invalidLinksSet, stats } = await checkLinksWithPanCheck(links);
         const before = candidates.length;
-        candidates = candidates.filter((c) => !invalidSet.has(text(c.share_link || c.link || "")));
+        candidates = candidates.filter((c) => !invalidLinksSet.has(text(c.share_link || c.link || "")));
+        if (stats) {
+          await OmniBox.log("info", `[detail] PanCheck 分平台统计: 输入=${JSON.stringify(stats.inputPlatformStats)}, 校验=${JSON.stringify(stats.checkedPlatformStats)}, 过滤=${JSON.stringify(stats.invalidPlatformStats)}, 剩余=${JSON.stringify(stats.validPlatformStats)}, 跳过=${JSON.stringify(stats.bypassPlatformStats)}`);
+          await OmniBox.log("info", `[detail] PanCheck 总统计: 总输入=${stats.totalInput}, 总校验=${stats.totalChecked}, 总过滤=${stats.totalInvalid}, 总剩余=${stats.totalOutput}, 其中直出=${stats.totalBypass}`);
+        }
         await OmniBox.log("info", `[detail] PanCheck 过滤完成 before=${before}, after=${candidates.length}, removed=${before - candidates.length}`);
       } catch (e) {
         await OmniBox.log("warn", `[detail] PanCheck 过滤失败，回退: ${e.message}`);
@@ -969,18 +1095,24 @@ async function play(params, context) {
     }
 
     // 观看记录（可选）
-    try {
-      await OmniBox.addPlayHistory({
-        vodId: text(meta.sourceVodId || resourceId || title),
-        title: title,
-        episode: playId,
-        episodeName: epName || undefined,
-        playUrl: urls[0].url,
-        playHeader: info?.header || { "User-Agent": UA, "Referer": `${BASE}/` }
+    Promise.resolve(OmniBox.addPlayHistory({
+      vodId: text(meta.sourceVodId || resourceId || title),
+      title: title,
+      episode: playId,
+      episodeName: epName || undefined,
+      playUrl: urls[0].url,
+      playHeader: info?.header || { "User-Agent": UA, "Referer": `${BASE}/` }
+    }))
+      .then(async (added) => {
+        if (added) {
+          await OmniBox.log("info", `[dyuzi] 已添加观看记录: ${title}`);
+        } else {
+          await OmniBox.log("info", `[dyuzi] 观看记录未写入(返回 falsy): ${title}`);
+        }
+      })
+      .catch(async (e) => {
+        await OmniBox.log("warn", `[dyuzi] 添加观看记录失败: ${e.message}`);
       });
-    } catch (e) {
-      await OmniBox.log("warn", `[dyuzi] 添加观看记录失败: ${e.message}`);
-    }
 
     return {
       urls,


### PR DESCRIPTION
## 变更内容

将前面已经落在 `盘搜分组.js` 的 PanCheck / 观看记录相关优化，同步到另外两份盘搜类脚本：

- `影视/网盘/盘搜.js`
- `影视/网盘/聚盘搜索.js`

### 1. 同步 PanCheck“先按平台过滤再送检”逻辑
- 当 `PANCHECK_PLATFORMS` 有配置值时，先按平台筛链接
- 只把命中的平台链接提交给 `PANCHECK_API`
- 未命中的平台不送检，但结果仍保留返回
- 已送检的平台继续只保留校验通过的部分

### 2. 同步默认平台值
默认 `PANCHECK_PLATFORMS` 改为：
- `quark,baidu,uc,pan123,tianyi,cmcc`

### 3. 同步平台命名归一化
补齐并统一这些平台名：
- `pan123 / 123pan / 123`
- `cmcc / mobile / 139`
- `aliyun / ali / alipan`
- `tianyi / tianyiyun`

同时补了基于分享链接域名的平台识别，减少只靠 SDK 返回值带来的漏判。

### 4. 同步 PanCheck 统计日志
新增：
- 分平台输入 / 校验 / 过滤 / 剩余 / 跳过统计
- 总输入 / 总校验 / 总过滤 / 总剩余 / 直出统计

### 5. 同步观看记录异步化
- `聚盘搜索.js` 的 `addPlayHistory` 改为异步非阻塞
- 成功、返回 falsy、失败日志都放到回调中打印
- `盘搜.js` 原本就已经是异步写入，本次保持一致风格

## 影响文件
- `影视/网盘/盘搜.js`
- `影视/网盘/聚盘搜索.js`

## 版本
- `盘搜.js`: `1.2.2 -> 1.2.3`
- `聚盘搜索.js`: `1.0.0 -> 1.0.1`

## 校验
- `node --check 影视/网盘/盘搜.js` 通过
- `node --check 影视/网盘/聚盘搜索.js` 通过
