### PR TITLE
fix: 兼容盘搜类脚本配置分隔符

### DIFF
--- a/影视/网盘/盘搜.js
+++ b/影视/网盘/盘搜.js
@@ -1,7 +1,7 @@
 // @name 盘搜
 // @author 
 // @description 刮削：支持，弹幕：支持，嗅探：支持
-// @version 1.2.3
+// @version 1.3.2
 // @downloadURL https://gh-proxy.org/https://github.com/Silent1566/OmniBox-Spider/raw/refs/heads/main/影视/网盘/盘搜.js
 /**
  * OmniBox 网盘爬虫脚本
@@ -13,10 +13,10 @@
  * 1. 配置盘搜API地址到环境变量 PANSOU_API 中，或直接修改下面的 PANSOU_API 常量
  * 2. （可选）配置盘搜频道到环境变量 PANSOU_CHANNELS 中
  * 3. （可选）配置盘搜插件到环境变量 PANSOU_PLUGINS 中
- * 4. （可选）配置网盘类型过滤到环境变量 PANSOU_CLOUD_TYPES 中（如：baidu,aliyun,quark）
+ * 4. （可选）配置网盘类型过滤到环境变量 PANSOU_CLOUD_TYPES 中（支持逗号/分号分隔，如：baidu,aliyun,quark 或 baidu;aliyun;quark）
  * 5. （可选）配置 PanCheck API 地址到环境变量 PANCHECK_API 中，用于过滤无效链接
  * 6. （可选）配置 PanCheck 是否启用到环境变量 PANCHECK_ENABLED 中（true/false，默认：如果配置了 PANCHECK_API 则启用）
- * 7. （可选）配置 PanCheck 选择的平台到环境变量 PANCHECK_PLATFORMS 中（如：baidu,aliyun,quark）
+ * 7. （可选）配置 PanCheck 选择的平台到环境变量 PANCHECK_PLATFORMS 中（支持逗号/分号分隔，如：baidu,aliyun,quark 或 baidu;aliyun;quark）
  * 8. （可选）配置 PanCheck 选择的平台到环境变量 PANSOU_FILTER 中（如：{"include":["合集","全集"],"exclude":["预告"]}）
  *
  * 使用方法：
@@ -43,8 +43,9 @@ const PANSOU_CHANNELS = process.env.PANSOU_CHANNELS || "";
 // 例如：plugin1,plugin2
 const PANSOU_PLUGINS = process.env.PANSOU_PLUGINS || "";
 
-// 网盘类型过滤（可选，多个用逗号分隔）
+// 网盘类型过滤（可选，多个支持逗号/分号分隔）
 // 例如：baidu,aliyun,quark,115,tianyi,xunlei,123,mobile,uc
+// 或：baidu;aliyun;quark;115;tianyi;xunlei;123;mobile;uc
 const PANSOU_CLOUD_TYPES = process.env.PANSOU_CLOUD_TYPES || "";
 
 // 关键词过滤
@@ -60,17 +61,25 @@ const PANCHECK_API = process.env.PANCHECK_API || "";
 // 如果配置了 PANCHECK_API，则默认启用
 const PANCHECK_ENABLED = true;
 
-// PanCheck 选择的平台（可选，多个用逗号分隔）
+// PanCheck 选择的平台（可选，多个支持逗号/分号分隔）
 // 例如：baidu,aliyun,quark,115,tianyi,xunlei,123,mobile,uc
+// 或：baidu;aliyun;quark;115;tianyi;xunlei;123;mobile;uc
 // 如果不配置，则检测所有平台
 const PANCHECK_PLATFORMS = process.env.PANCHECK_PLATFORMS || "quark,baidu,uc,pan123,tianyi,cmcc";
 
-// 网盘类型匹配配置: 使用分号分隔，例如 quark;uc
-const DRIVE_TYPE_CONFIG = (process.env.DRIVE_TYPE_CONFIG || "quark;uc").split(';').map((t) => t.trim()).filter(Boolean);
-// 线路名称配置: 使用分号分隔，例如 本地代理;服务端代理;直连
-const SOURCE_NAMES_CONFIG = (process.env.SOURCE_NAMES_CONFIG || "本地代理;服务端代理;直连").split(';').map((s) => s.trim()).filter(Boolean);
+function splitConfigList(value) {
+  return String(value || "")
+    .split(/[;,]/)
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+// 网盘类型匹配配置: 支持逗号/分号分隔，例如 quark;uc 或 quark,uc
+const DRIVE_TYPE_CONFIG = splitConfigList(process.env.DRIVE_TYPE_CONFIG || "quark;uc");
+// 线路名称配置: 支持逗号/分号分隔，例如 本地代理;服务端代理;直连
+const SOURCE_NAMES_CONFIG = splitConfigList(process.env.SOURCE_NAMES_CONFIG || "本地代理;服务端代理;直连");
 // 详情页播放线路的网盘排序顺序，仅作用于 detail() 返回的播放线路
-const DRIVE_ORDER = (process.env.DRIVE_ORDER || "baidu;tianyi;quark;uc;115;xunlei;ali;123pan").split(';').map((s) => s.trim().toLowerCase()).filter(Boolean);
+const DRIVE_ORDER = splitConfigList(process.env.DRIVE_ORDER || "baidu;tianyi;quark;uc;115;xunlei;ali;123pan").map((s) => s.toLowerCase());
 // 详情链路缓存时间（秒），默认 12 小时
 const PANSOU_CACHE_EX_SECONDS = Number(process.env.PANSOU_CACHE_EX_SECONDS || 43200);
 
@@ -144,9 +153,8 @@ function inferDriveTypeFromResult(item = {}) {
 }
 
 function getPanCheckSelectedPlatforms() {
-  return String(PANCHECK_PLATFORMS || "")
-    .split(",")
-    .map((p) => normalizePanCheckPlatform(p.trim()))
+  return splitConfigList(PANCHECK_PLATFORMS)
+    .map((p) => normalizePanCheckPlatform(p))
     .filter(Boolean);
 }
 
@@ -226,7 +234,7 @@ async function requestPansouAPI(params = {}) {
     body.plugins = PANSOU_PLUGINS.split(',');;
   }
   if (PANSOU_CLOUD_TYPES) {
-    body.cloud_types = PANSOU_CLOUD_TYPES.split(',');;
+    body.cloud_types = splitConfigList(PANSOU_CLOUD_TYPES);
   }
   if (PANSOU_FILTER) {
     body.filter = PANSOU_FILTER;

--- a/影视/网盘/盘搜分组.js
+++ b/影视/网盘/盘搜分组.js
@@ -1,7 +1,7 @@
 // @name 盘搜分组
 // @author 
 // @description 刮削：支持，弹幕：支持，嗅探：支持，只支持tvbox接口
-// @version 1.1.6
+// @version 1.2.2
 // @downloadURL https://gh-proxy.org/https://github.com/Silent1566/OmniBox-Spider/raw/refs/heads/main/影视/网盘/盘搜分组.js
 
 /**
@@ -14,10 +14,10 @@
 * 1. 配置盘搜API地址到环境变量 PANSOU_API 中,或直接修改下面的 PANSOU_API 常量
 * 2. (可选)配置盘搜频道到环境变量 PANSOU_CHANNELS 中
 * 3. (可选)配置盘搜插件到环境变量 PANSOU_PLUGINS 中
-* 4. (可选)配置网盘类型过滤到环境变量 PANSOU_CLOUD_TYPES 中(如:baidu,aliyun,quark)
+* 4. (可选)配置网盘类型过滤到环境变量 PANSOU_CLOUD_TYPES 中(支持逗号/分号分隔,如:baidu,aliyun,quark 或 baidu;aliyun;quark)
 * 5. (可选)配置 PanCheck API 地址到环境变量 PANCHECK_API 中,用于过滤无效链接
 * 6. (可选)配置 PanCheck 是否启用到环境变量 PANCHECK_ENABLED 中(true/false,默认:如果配置了 PANCHECK_API 则启用)
-* 7. (可选)配置 PanCheck 选择的平台到环境变量 PANCHECK_PLATFORMS 中(如:baidu,aliyun,quark)
+* 7. (可选)配置 PanCheck 选择的平台到环境变量 PANCHECK_PLATFORMS 中(支持逗号/分号分隔,如:baidu,aliyun,quark 或 baidu;aliyun;quark)
 * 8. (可选)配置 PANSOU_FILTER 中(如:{"include":["合集","全集"],"exclude":["预告"]})
 */
 
@@ -33,12 +33,19 @@ const PANCHECK_API = process.env.PANCHECK_API || "";
 const PANCHECK_ENABLED = true;
 const PANCHECK_PLATFORMS = process.env.PANCHECK_PLATFORMS || "quark,baidu,uc,pan123,tianyi,cmcc";
 
-// 网盘类型匹配配置: 使用分号分隔，例如 quark;uc
-const DRIVE_TYPE_CONFIG = (process.env.DRIVE_TYPE_CONFIG || "quark;uc").split(';').map((t) => t.trim()).filter(Boolean);
-// 线路名称配置: 使用分号分隔，例如 本地代理;服务端代理;直连
-const SOURCE_NAMES_CONFIG = (process.env.SOURCE_NAMES_CONFIG || "本地代理;服务端代理;直连").split(';').map((s) => s.trim()).filter(Boolean);
+function splitConfigList(value) {
+    return String(value || "")
+        .split(/[;,]/)
+        .map((item) => item.trim())
+        .filter(Boolean);
+}
+
+// 网盘类型匹配配置: 支持逗号/分号分隔，例如 quark;uc 或 quark,uc
+const DRIVE_TYPE_CONFIG = splitConfigList(process.env.DRIVE_TYPE_CONFIG || "quark;uc");
+// 线路名称配置: 支持逗号/分号分隔，例如 本地代理;服务端代理;直连
+const SOURCE_NAMES_CONFIG = splitConfigList(process.env.SOURCE_NAMES_CONFIG || "本地代理;服务端代理;直连");
 // 详情页播放线路和搜索分组的网盘排序顺序
-const DRIVE_ORDER = (process.env.DRIVE_ORDER || "baidu;tianyi;quark;uc;115;xunlei;ali;123pan").split(';').map((s) => s.trim().toLowerCase()).filter(Boolean);
+const DRIVE_ORDER = splitConfigList(process.env.DRIVE_ORDER || "baidu;tianyi;quark;uc;115;xunlei;ali;123pan").map((s) => s.toLowerCase());
 // 详情链路缓存时间（秒），默认 12 小时
 const PANSOU_GROUP_CACHE_EX_SECONDS = Number(process.env.PANSOU_GROUP_CACHE_EX_SECONDS || 43200);
 // 是否异步刮削，默认 true。仅当明确配置为 false 时才走同步刮削。
@@ -249,7 +256,7 @@ async function requestPansouAPI(params = {}) {
     if (params.cloud_types) {
         body.cloud_types = params.cloud_types;
     } else if (PANSOU_CLOUD_TYPES) {
-        body.cloud_types = PANSOU_CLOUD_TYPES.split(',');
+        body.cloud_types = splitConfigList(PANSOU_CLOUD_TYPES);
     }
     if (PANSOU_FILTER) {
         body.filter = PANSOU_FILTER;
@@ -286,9 +293,8 @@ async function requestPansouAPI(params = {}) {
 * 调用 PanCheck API 检测链接有效性
 */
 function getPanCheckSelectedPlatforms() {
-    return String(PANCHECK_PLATFORMS || "")
-        .split(",")
-        .map((p) => normalizeDriveType(p.trim()))
+    return splitConfigList(PANCHECK_PLATFORMS)
+        .map((p) => normalizeDriveType(p))
         .filter(Boolean);
 }
 

--- a/影视/网盘/聚盘搜索.js
+++ b/影视/网盘/聚盘搜索.js
@@ -2,7 +2,7 @@
 // @author 梦
 // @description 站点搜索 + 网盘资源解析（夸克/百度/迅雷等），支持网盘目录展开、刮削、弹幕、观看记录
 // @dependencies: axios
-// @version 1.0.1
+// @version 1.1.2
 // @downloadURL https://gh-proxy.org/https://github.com/Silent1566/OmniBox-Spider/raw/refs/heads/main/影视/网盘/聚盘搜索.js
 
 
@@ -23,7 +23,7 @@ const SEARCH_POLL_INTERVAL_MS = 900;
 // 用法：在搜索结果落地前，先把全部 share_link 汇总成一批，调用一次 pancheck，再过滤无效链接
 const PANCHECK_API = text(process.env.PANCHECK_API || "");
 const PANCHECK_ENABLED = text(process.env.PANCHECK_ENABLED || (PANCHECK_API ? "1" : "0")) === "1";
-const PANCHECK_PLATFORMS = text(process.env.PANCHECK_PLATFORMS || "quark,baidu,uc,pan123,tianyi,cmcc"); // 例：quark,baidu,xunlei
+const PANCHECK_PLATFORMS = text(process.env.PANCHECK_PLATFORMS || "quark,baidu,uc,pan123,tianyi,cmcc"); // 例：quark,baidu,xunlei 或 quark;baidu;xunlei
 
 // 网盘排序配置（必须置于顶部配置区，便于统一管理）
 const DRIVE_ORDER_DEFAULT = "百度网盘,天翼网盘,夸克网盘,UC网盘,115网盘,迅雷网盘,阿里网盘";
@@ -41,6 +41,13 @@ const http = axios.create({
 
 function text(v) {
   return String(v == null ? "" : v).trim();
+}
+
+function splitConfigList(v) {
+  return text(v)
+    .split(/[;,]/)
+    .map((item) => item.trim())
+    .filter(Boolean);
 }
 
 function sleep(ms) {
@@ -373,8 +380,7 @@ function normalizeDriveType(driveTypeRaw, link) {
 }
 
 function getPanCheckSelectedPlatforms() {
-  return text(PANCHECK_PLATFORMS)
-    .split(",")
+  return splitConfigList(PANCHECK_PLATFORMS)
     .map((x) => driveAliasToCode(x))
     .filter(Boolean);
 }
@@ -416,6 +422,7 @@ function splitLinksByPanCheckPlatforms(links = []) {
  * 默认顺序：百度 → 天翼 → 夸克 → UC → 115 → 迅雷 → 阿里
  * 配置示例：DRIVE_ORDER=夸克网盘,百度网盘,迅雷网盘
  *           DRIVE_ORDER=quark,baidu,xunlei
+ *           DRIVE_ORDER=quark;baidu;xunlei
  */
 function parseDriveOrderEnv() {
   const DEFAULT_ORDER = ["baidu", "tianyiyun", "quark", "uc", "115", "xunlei", "aliyun"];
@@ -423,7 +430,7 @@ function parseDriveOrderEnv() {
   if (!raw) return DEFAULT_ORDER;
 
   const out = [];
-  for (const part of raw.split(",").map(x => x.trim()).filter(Boolean)) {
+  for (const part of splitConfigList(raw)) {
     const code = driveAliasToCode(part);
     if (code && !out.includes(code)) out.push(code);
   }


### PR DESCRIPTION
## 变更说明
- 为 `盘搜`、`盘搜分组`、`聚盘搜索` 补充配置列表分隔符兼容，统一支持逗号与分号
- 修复 `PANCHECK_PLATFORMS` 使用分号时只识别到单个平台的问题
- 同步更新脚本内环境变量注释，明确说明支持 `a,b,c` 和 `a;b;c` 两种写法

## 涉及文件
- `影视/网盘/盘搜.js`
- `影视/网盘/盘搜分组.js`
- `影视/网盘/聚盘搜索.js`

## 验证
- `node --check 影视/网盘/盘搜.js`
- `node --check 影视/网盘/盘搜分组.js`
- `node --check 影视/网盘/聚盘搜索.js`
