### PR TITLE
chore: 移除部分脚本的 index 注解

### DIFF
--- a/影视/采集/HDmoli.js
+++ b/影视/采集/HDmoli.js
@@ -1,6 +1,5 @@
 // @name HDmoli
-// @version 1.0.5
-// @indexs 1
+// @version 1.0.6
 // @downloadURL https://gh-proxy.org/https://github.com/Silent1566/OmniBox-Spider/raw/refs/heads/main/影视/采集/HDmoli.js
 // @dependencies cheerio
 

--- a/短剧/星星短剧.js
+++ b/短剧/星星短剧.js
@@ -1,6 +1,5 @@
 // @name 星星短剧 ᵈᶻ[短]
-// @version 1.0.2
-// @indexs 1
+// @version 1.0.3
 // @push 0
 // @dependencies axios
 // @downloadURL https://gh-proxy.org/https://github.com/Silent1566/OmniBox-Spider/raw/refs/heads/main/短剧/星星短剧.js

--- a/音乐/DJ音乐.js
+++ b/音乐/DJ音乐.js
@@ -1,8 +1,7 @@
 // @name DJ音乐[听] - OmniBox
-// @version 1.0.4
+// @version 1.0.5
 // @author https://github.com/hjdhnx/drpy-node/blob/main/spider/js/DJ%E9%9F%B3%E4%B9%90%5B%E5%90%AC%5D.js
 // @origin https://github.com/hjdhnx/drpy-node/blob/main/spider/js/DJ%E9%9F%B3%E4%B9%90%5B%E5%90%AC%5D.js
-// @indexs 1
 // @push 0
 // @dependencies cheerio
 // @downloadURL https://gh-proxy.org/https://github.com/Silent1566/OmniBox-Spider/raw/refs/heads/main/音乐/DJ音乐.js


### PR DESCRIPTION
## 变更说明
- 移除以下脚本中的 `@indexs 1` 注解：
  - `影视/采集/HDmoli.js`
  - `短剧/星星短剧.js`
  - `音乐/DJ音乐.js`
- 保留 `模板/JavaScript/豆瓣推荐.js` 的 `@indexs 1` 不变
- 同步按变更升级脚本版本号

## 验证
- `node --check 影视/采集/HDmoli.js`
- `node --check 短剧/星星短剧.js`
- `node --check 音乐/DJ音乐.js`
