### PR TITLE
chore: 补齐脚本依赖注解

### DIFF
--- a/动漫/嗷呜动漫.js
+++ b/动漫/嗷呜动漫.js
@@ -1,7 +1,8 @@
 // @name 嗷呜动漫
 // @author 
 // @description 刮削：支持，弹幕：支持，嗅探：支持
-// @version 1.0.4
+// @dependencies: axios, cheerio
+// @version 1.0.5
 // @downloadURL https://gh-proxy.org/https://github.com/Silent1566/OmniBox-Spider/raw/refs/heads/main/动漫/嗷呜动漫.js
 /**
 * ============================================================================

--- a/影视/采集/88看球.js
+++ b/影视/采集/88看球.js
@@ -1,4 +1,6 @@
 // @name 88看球
+// @dependencies: axios, cheerio, crypto-js
+// @version 1.0.1
 // @downloadURL https://gh-proxy.org/https://github.com/Silent1566/OmniBox-Spider/raw/refs/heads/main/影视/采集/88看球.js
 /**
  * 刮削：不支持

--- a/影视/采集/TVB云播.js
+++ b/影视/采集/TVB云播.js
@@ -1,8 +1,8 @@
 // @name TVB云播
 // @author 
 // @description 刮削：支持，弹幕：支持，嗅探：支持
-// @dependencies: axios
-// @version 1.0.1
+// @dependencies: axios, cheerio
+// @version 1.0.2
 // @downloadURL https://gh-proxy.org/https://github.com/Silent1566/OmniBox-Spider/raw/refs/heads/main/影视/采集/TVB云播.js
 
 

--- a/影视/采集/两个BT.js
+++ b/影视/采集/两个BT.js
@@ -1,7 +1,8 @@
 // @name 两个BT
 // @author 
 // @description 刮削：支持，弹幕：支持，嗅探：支持
-// @version 1.0.5
+// @dependencies: axios, cheerio
+// @version 1.0.6
 // @downloadURL https://gh-proxy.org/https://github.com/Silent1566/OmniBox-Spider/raw/refs/heads/main/影视/采集/两个BT.js
 /**
  * ============================================================================

--- a/影视/采集/乐兔.js
+++ b/影视/采集/乐兔.js
@@ -1,7 +1,8 @@
 // @name 乐兔
 // @author 
 // @description 刮削：支持，弹幕：支持，嗅探：支持，广告：有
-// @version 1.0.5
+// @dependencies: axios, cheerio
+// @version 1.0.6
 // @downloadURL https://gh-proxy.org/https://github.com/Silent1566/OmniBox-Spider/raw/refs/heads/main/影视/采集/乐兔.js
 
 const axios = require("axios");

--- a/影视/采集/修罗影视.js
+++ b/影视/采集/修罗影视.js
@@ -1,8 +1,8 @@
 // @name 修罗影视
 // @author 
 // @description 刮削：支持，弹幕：支持，嗅探：支持
-// @dependencies: axios, crypto-js
-// @version 1.0.3
+// @dependencies: axios, cheerio, crypto-js
+// @version 1.0.4
 // @downloadURL https://gh-proxy.org/https://github.com/Silent1566/OmniBox-Spider/raw/refs/heads/main/影视/采集/修罗影视.js
 
 /**


### PR DESCRIPTION
## 变更说明
- 为仓库中实际使用外部依赖但缺少 `@dependencies` 注解的脚本补齐依赖声明
- 同步按变更升级对应脚本版本号
- 本轮覆盖：
  - `动漫/嗷呜动漫.js`
  - `影视/采集/88看球.js`
  - `影视/采集/TVB云播.js`
  - `影视/采集/两个BT.js`
  - `影视/采集/乐兔.js`
  - `影视/采集/修罗影视.js`

## 说明
- 已重新扫描仓库，当前“实际有外部依赖但没有依赖注解”的结果为 0
- `嗷呜动漫.js` 的 `node --check` 会被外部工具预检误报历史字符串中的 `$ID1`，本次仅修改头注释，不涉及该业务逻辑

## 验证
- 复扫仓库后，缺失依赖注解数量：`0`
- `node --check` 已通过：
  - `影视/采集/88看球.js`
  - `影视/采集/TVB云播.js`
  - `影视/采集/两个BT.js`
  - `影视/采集/乐兔.js`
  - `影视/采集/修罗影视.js`
