### PR TITLE
fix: 限定 Gimy剧迷 搜索结果为主结果区内容

### DIFF
--- a/影视/采集/Gimy剧迷.js
+++ b/影视/采集/Gimy剧迷.js
@@ -1,8 +1,8 @@
 // @name Gimy剧迷
 // @author 梦
 // @description 影视站：Gimy / gimy.now / gimyai.tw，支持首页、分类、详情、搜索与播放页嗅探
-// @dependencies cheerio
-// @version 1.0.5
+// @dependencies cheerio,@types/opencc-js
+// @version 1.2.1
 // @downloadURL https://gh-proxy.org/https://github.com/Silent1566/OmniBox-Spider/raw/refs/heads/main/影视/采集/Gimy剧迷.js
 
 const OmniBox = require("omnibox_sdk");
@@ -11,6 +11,10 @@ const cheerio = require("cheerio");
 
 const BASE_URL = "https://gimyai.tw";
 const UA = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.0.0 Safari/537.36";
+
+let simplifyConverter = null;
+let simplifyConverterName = "fallback-map";
+let simplifyConverterChecked = false;
 
 module.exports = { home, category, detail, search, play };
 runner.run(module.exports);
@@ -54,7 +58,7 @@ function normalizeText(value) {
   return String(value || "").replace(/<[^>]+>/g, " ").replace(/&nbsp;/gi, " ").replace(/\s+/g, " ").trim();
 }
 
-function toSearchComparable(value) {
+function fallbackTraditionalToSimplified(value) {
   const map = {
     "鬥": "斗", "羅": "罗", "陸": "陆", "龍": "龙", "傳": "传", "說": "说", "絕": "绝", "劍": "剑", "塵": "尘",
     "動": "动", "態": "态", "畫": "画", "劇": "剧", "場": "场", "國": "国", "產": "产", "綜": "综", "藝": "艺",
@@ -64,14 +68,152 @@ function toSearchComparable(value) {
     "極": "极", "歲": "岁", "當": "当", "這": "这", "個": "个", "們": "们", "為": "为", "總": "总", "實": "实",
     "陰": "阴", "陽": "阳", "聖": "圣", "靈": "灵", "夢": "梦", "戀": "恋", "網": "网", "寶": "宝", "藍": "蓝",
     "覺": "觉", "經": "经", "終": "终", "貝": "贝", "幾": "几", "體": "体", "頭": "头", "師": "师",
-    "慶": "庆", "餘": "余", "館": "馅", "漢": "汉", "門": "门", "趙": "赵", "滄": "沧", "粵": "粤", "語": "语",
-    "專": "专", "區": "区", "號": "号", "劃": "划", "燈": "灯", "貴": "贵", "顏": "颜", "廣": "广", "澤": "泽"
+    "慶": "庆", "餘": "余", "館": "馆", "漢": "汉", "趙": "赵", "滄": "沧", "粵": "粤", "語": "语",
+    "專": "专", "區": "区", "號": "号", "劃": "划", "燈": "灯", "貴": "贵", "顏": "颜", "廣": "广", "澤": "泽",
+    "遲": "迟", "歡": "欢", "鱗": "鳞", "綺": "绮", "紀": "纪", "義": "义", "獄": "狱", "滬": "沪", "灣": "湾",
+    "峽": "峡", "層": "层", "樓": "楼", "鹽": "盐", "澀": "涩", "歸": "归", "樂": "乐", "豐": "丰", "俠": "侠",
+    "俁": "俣", "優": "优", "偉": "伟", "側": "侧", "僅": "仅", "價": "价", "儀": "仪", "億": "亿", "儲": "储",
+    "兒": "儿", "剛": "刚", "劉": "刘", "勁": "劲", "勞": "劳", "勳": "勋", "匯": "汇", "華": "华", "協": "协",
+    "單": "单", "衛": "卫", "廳": "厅", "厲": "厉", "壓": "压", "參": "参", "叢": "丛", "吳": "吴", "啟": "启",
+    "喬": "乔", "喚": "唤", "嘆": "叹", "嘯": "啸", "噸": "吨", "嚴": "严", "園": "园", "團": "团", "圍": "围",
+    "壘": "垒", "壞": "坏", "壯": "壮", "壽": "寿", "夠": "够", "夢": "梦", "奪": "夺", "奮": "奋", "奧": "奥",
+    "奬": "奖", "婦": "妇", "媽": "妈", "嫻": "娴", "學": "学", "寧": "宁", "實": "实", "對": "对", "導": "导",
+    "將": "将", "專": "专", "尋": "寻", "對": "对", "屆": "届", "岡": "冈", "島": "岛", "峯": "峰", "峽": "峡",
+    "巔": "巅", "幣": "币", "幫": "帮", "幹": "干", "庫": "库", "廢": "废", "彈": "弹", "強": "强", "彥": "彦",
+    "徑": "径", "徹": "彻", "憂": "忧", "應": "应", "懷": "怀", "懸": "悬", "懲": "惩", "戶": "户", "拋": "抛",
+    "挾": "挟", "捨": "舍", "掃": "扫", "掄": "抡", "揚": "扬", "換": "换", "揮": "挥", "損": "损", "搖": "摇",
+    "攝": "摄", "擁": "拥", "據": "据", "擇": "择", "擊": "击", "擋": "挡", "擾": "扰", "擴": "扩", "攝": "摄",
+    "擺": "摆", "斂": "敛", "斃": "毙", "斕": "斓", "於": "于", "暈": "晕", "曉": "晓", "曆": "历", "曠": "旷",
+    "曬": "晒", "曉": "晓", "書": "书", "朧": "胧", "殺": "杀", "條": "条", "梟": "枭", "棄": "弃", "榮": "荣",
+    "槍": "枪", "槓": "杠", "樁": "桩", "橋": "桥", "機": "机", "檔": "档", "檢": "检", "歡": "欢", "歐": "欧",
+    "歲": "岁", "殘": "残", "殿": "殿", "氣": "气", "決": "决", "沒": "没", "沖": "冲", "況": "况", "滾": "滚",
+    "滿": "满", "潔": "洁", "潛": "潜", "澤": "泽", "濃": "浓", "濤": "涛", "濟": "济", "濱": "滨", "瀾": "澜",
+    "灣": "湾", "營": "营", "爍": "烁", "爐": "炉", "爭": "争", "爾": "尔", "獨": "独", "獅": "狮", "獻": "献",
+    "璣": "玑", "環": "环", "瓊": "琼", "甄": "甄", "產": "产", "當": "当", "瘋": "疯", "盜": "盗", "盤": "盘",
+    "盧": "卢", "監": "监", "盪": "荡", "矚": "瞩", "矯": "矫", "硤": "硖", "礎": "础", "禍": "祸", "禦": "御",
+    "禪": "禅", "種": "种", "稱": "称", "穀": "谷", "窩": "窝", "競": "竞", "筆": "笔", "築": "筑", "籃": "篮",
+    "糰": "团", "糾": "纠", "紀": "纪", "約": "约", "級": "级", "紋": "纹", "納": "纳", "純": "纯", "紙": "纸",
+    "紛": "纷", "素": "素", "紮": "扎", "紹": "绍", "終": "终", "組": "组", "細": "细", "結": "结", "絃": "弦",
+    "給": "给", "絕": "绝", "統": "统", "絲": "丝", "經": "经", "綁": "绑", "維": "维", "綱": "纲", "網": "网",
+    "緊": "紧", "緒": "绪", "練": "练", "縣": "县", "縱": "纵", "總": "总", "績": "绩", "織": "织", "繞": "绕",
+    "繼": "继", "續": "续", "罷": "罢", "羋": "芈", "習": "习", "翹": "翘", "翻": "翻", "聯": "联", "聲": "声",
+    "職": "职", "肅": "肃", "腦": "脑", "腳": "脚", "脈": "脉", "腫": "肿", "臺": "台", "艦": "舰", "艱": "艰",
+    "艷": "艳", "藝": "艺", "節": "节", "莊": "庄", "蒼": "苍", "蓋": "盖", "蓮": "莲", "蔣": "蒋", "蕭": "萧",
+    "薩": "萨", "藥": "药", "虜": "虏", "號": "号", "蛻": "蜕", "蝕": "蚀", "衛": "卫", "補": "补", "裝": "装",
+    "複": "复", "襲": "袭", "覈": "核", "覓": "觅", "覽": "览", "觸": "触", "訂": "订", "訃": "讣", "計": "计",
+    "訊": "讯", "託": "托", "記": "记", "訓": "训", "訴": "诉", "診": "诊", "詐": "诈", "詔": "诏", "評": "评",
+    "詞": "词", "詠": "咏", "詢": "询", "試": "试", "詩": "诗", "話": "话", "該": "该", "詳": "详", "誅": "诛",
+    "誠": "诚", "誤": "误", "說": "说", "誰": "谁", "課": "课", "調": "调", "談": "谈", "請": "请", "諒": "谅",
+    "諜": "谍", "諾": "诺", "謀": "谋", "謊": "谎", "謎": "谜", "講": "讲", "謝": "谢", "譚": "谭", "譜": "谱",
+    "譯": "译", "議": "议", "護": "护", "讀": "读", "變": "变", "讓": "让", "豐": "丰", "貓": "猫", "貫": "贯",
+    "責": "责", "貧": "贫", "貨": "货", "販": "贩", "貪": "贪", "貫": "贯", "賀": "贺", "賈": "贾", "資": "资",
+    "賊": "贼", "賓": "宾", "賜": "赐", "賞": "赏", "賠": "赔", "賢": "贤", "賣": "卖", "質": "质", "賴": "赖",
+    "贈": "赠", "贏": "赢", "趕": "赶", "趙": "赵", "跡": "迹", "踐": "践", "踴": "踊", "蹟": "迹", "車": "车",
+    "軌": "轨", "軍": "军", "軟": "软", "較": "较", "輛": "辆", "輝": "辉", "輩": "辈", "輪": "轮", "輯": "辑",
+    "輸": "输", "轟": "轰", "辦": "办", "邁": "迈", "還": "还", "邊": "边", "郵": "邮", "鄉": "乡", "鄧": "邓",
+    "鄭": "郑", "醜": "丑", "醫": "医", "醬": "酱", "釀": "酿", "釋": "释", "針": "针", "鈴": "铃", "鈺": "钰",
+    "鉅": "巨", "鉤": "钩", "銀": "银", "銃": "铳", "銅": "铜", "銘": "铭", "銳": "锐", "鋒": "锋", "錘": "锤",
+    "錦": "锦", "鍋": "锅", "鎖": "锁", "鐘": "钟", "鐵": "铁", "鑄": "铸", "鑑": "鉴", "長": "长", "門": "门",
+    "開": "开", "閃": "闪", "閉": "闭", "問": "问", "聞": "闻", "閩": "闽", "閣": "阁", "闖": "闯", "關": "关",
+    "陣": "阵", "陽": "阳", "際": "际", "雜": "杂", "離": "离", "難": "难", "雲": "云", "雷": "雷", "霧": "雾",
+    "靜": "静", "響": "响", "頂": "顶", "頃": "顷", "項": "项", "順": "顺", "須": "须", "頑": "顽", "頓": "顿",
+    "頒": "颁", "頗": "颇", "領": "领", "頭": "头", "頰": "颊", "顆": "颗", "顧": "顾", "顫": "颤", "顯": "显",
+    "顱": "颅", "顴": "颧", "風": "风", "飛": "飞", "飯": "饭", "飲": "饮", "飼": "饲", "館": "馆", "駁": "驳",
+    "駕": "驾", "騎": "骑", "騙": "骗", "騰": "腾", "驅": "驱", "驗": "验", "驚": "惊", "髒": "脏", "鬚": "须",
+    "鬧": "闹", "鬱": "郁", "魚": "鱼", "魯": "鲁", "鮑": "鲍", "鮮": "鲜", "鯨": "鲸", "鳴": "鸣", "鷹": "鹰",
+    "麗": "丽", "麥": "麦", "黃": "黄", "點": "点", "黨": "党", "齊": "齐", "齒": "齿", "龍": "龙"
   };
   return String(value || "").split("").map((ch) => map[ch] || ch).join("");
 }
 
+function getSimplifyConverter() {
+  if (simplifyConverterChecked) return simplifyConverter;
+  simplifyConverterChecked = true;
+
+  if (String(process.env.GIMY_DISABLE_OPENCC || "").trim() === "1") {
+    simplifyConverterName = "fallback-map";
+    simplifyConverter = fallbackTraditionalToSimplified;
+    return simplifyConverter;
+  }
+
+  try {
+    const conv = require("chinese-conv");
+    if (conv && typeof conv.sify === "function") {
+      simplifyConverterName = "chinese-conv";
+      simplifyConverter = (text) => conv.sify(String(text || ""));
+      return simplifyConverter;
+    }
+  } catch (_) {}
+
+  try {
+    const rsOpencc = require("@node-rs/opencc");
+    if (rsOpencc && typeof rsOpencc.t2s === "function") {
+      simplifyConverterName = "@node-rs/opencc:t2s";
+      simplifyConverter = (text) => rsOpencc.t2s(String(text || ""));
+      return simplifyConverter;
+    }
+    if (rsOpencc && typeof rsOpencc.OpenCC === "function") {
+      const cc = new rsOpencc.OpenCC("t2s.json");
+      if (typeof cc.convertSync === "function") {
+        simplifyConverterName = "@node-rs/opencc:OpenCC";
+        simplifyConverter = (text) => cc.convertSync(String(text || ""));
+        return simplifyConverter;
+      }
+    }
+  } catch (_) {}
+
+  try {
+    const openccJs = require("opencc-js");
+    if (openccJs && typeof openccJs.Converter === "function") {
+      const converter = openccJs.Converter({ from: "t", to: "cn" });
+      if (typeof converter === "function") {
+        simplifyConverterName = "opencc-js";
+        simplifyConverter = (text) => converter(String(text || ""));
+        return simplifyConverter;
+      }
+    }
+  } catch (_) {}
+
+  try {
+    const opencc = require("opencc");
+    if (opencc && typeof opencc.OpenCC === "function") {
+      const cc = new opencc.OpenCC("t2s.json");
+      if (typeof cc.convertSync === "function") {
+        simplifyConverterName = "opencc:convertSync";
+        simplifyConverter = (text) => cc.convertSync(String(text || ""));
+        return simplifyConverter;
+      }
+    }
+    if (opencc && typeof opencc.t2s === "function") {
+      simplifyConverterName = "opencc:t2s";
+      simplifyConverter = (text) => opencc.t2s(String(text || ""));
+      return simplifyConverter;
+    }
+  } catch (_) {}
+
+  simplifyConverterName = "fallback-map";
+  simplifyConverter = fallbackTraditionalToSimplified;
+  return simplifyConverter;
+}
+
+function convertTraditionalToSimplified(value) {
+  const text = String(value || "");
+  try {
+    const converter = getSimplifyConverter();
+    const result = converter ? converter(text) : text;
+    return String(result || text);
+  } catch (_) {
+    simplifyConverterName = "fallback-map";
+    return fallbackTraditionalToSimplified(text);
+  }
+}
+
+function toDisplayText(value) {
+  return convertTraditionalToSimplified(normalizeText(value));
+}
+
 function normalizeSearchKeyword(value) {
-  return toSearchComparable(String(value || ""))
+  return convertTraditionalToSimplified(String(value || ""))
     .replace(/[\s\-_—–·•:：,，.。!?！？'"“”‘’()（）\[\]【】{}]/g, "")
     .toLowerCase();
 }
@@ -105,33 +247,18 @@ function scoreSearchResult(vodName, keyword) {
   return score;
 }
 
-function refineSearchResults(list, keyword) {
-  const scored = list.map((item) => ({ item, score: scoreSearchResult(item.vod_name, keyword) }));
-  const matched = scored
-    .filter((entry) => entry.score > 0)
-    .sort((a, b) => b.score - a.score || String(a.item.vod_name || "").localeCompare(String(b.item.vod_name || ""), "zh-Hans-CN"))
-    .map((entry) => entry.item);
-
-  if (matched.length) return matched;
-
-  const looseKeyword = normalizeSearchKeyword(keyword);
-  const loose = list.filter((item) => normalizeSearchKeyword(item.vod_name).includes(looseKeyword));
-  if (loose.length) return loose;
-
-  return [];
-}
-
-function extractCards($) {
+function extractCards($, scope) {
   const list = [];
   const seen = new Set();
+  const $scope = scope && scope.length ? scope : $.root();
 
-  $("a[href*='/detail/']").each((_, el) => {
+  $scope.find("a[href*='/detail/']").each((_, el) => {
     const $el = $(el);
     const href = $el.attr("href") || "";
     const vod_id = absUrl(href);
     if (!/\/detail\/\d+\.html/i.test(vod_id) || seen.has(vod_id)) return;
 
-    const title = normalizeText(
+    const title = toDisplayText(
       $el.attr("title")
       || $el.find("img").attr("alt")
       || $el.find(".title, .video-text, .module-poster-item-title, h3, h4, h5").first().text()
@@ -155,7 +282,7 @@ function extractCards($) {
     );
     const parentHtml = $el.closest("li, .module-item, .public-list-box, .video-item, .item, .module-poster-item, .myui-vodlist__box").html() || $el.parent().html() || "";
     const remarksMatch = String(parentHtml).match(/(?:更新至第?\d+集|更新第?\d+集|\(?\d+全\)?|全\d+集|已完結|已完结|HD中字|HD|TC|HC|搶先版|抢先版)/i);
-    const vod_remarks = remarksMatch ? normalizeText(remarksMatch[0]) : "";
+    const vod_remarks = remarksMatch ? toDisplayText(remarksMatch[0]) : "";
 
     seen.add(vod_id);
     list.push({ vod_id, vod_name: title, vod_pic: pic, vod_remarks });
@@ -199,6 +326,8 @@ function buildClassAndFilters() {
 
 async function home(params, context) {
   try {
+    getSimplifyConverter();
+    await OmniBox.log("info", `[Gimy剧迷][display] simplifyConverter=${simplifyConverterName}`);
     const config = buildClassAndFilters();
     const html = await requestText(`${BASE_URL}/`);
     const $ = cheerio.load(html);
@@ -241,7 +370,7 @@ function parsePlaySources($) {
     const $el = $(el);
     const href = $el.attr("href") || "";
     const tabId = href.replace(/^#/, "");
-    const name = normalizeText($el.text()) || tabId;
+    const name = toDisplayText($el.text()) || tabId;
     if (tabId) tabs.push({ tabId, name });
   });
 
@@ -251,7 +380,7 @@ function parsePlaySources($) {
     $(`#${tab.tabId} a[href*='/play/']`).each((_, a) => {
       const $a = $(a);
       const href = $a.attr("href") || "";
-      const epName = normalizeText($a.text()) || "正片";
+      const epName = toDisplayText($a.text()) || "正片";
       if (!href) return;
       episodes.push({ name: epName, playId: absUrl(href) });
     });
@@ -264,7 +393,7 @@ function pickInfo(html, label) {
   const re = new RegExp(`<span[^>]*>${label}[：:]<\\/span>([\\s\\S]*?)<\\/li>`, "i");
   const m = String(html || "").match(re);
   if (!m) return "";
-  return normalizeText(m[1]);
+  return toDisplayText(m[1]);
 }
 
 async function detail(params, context) {
@@ -275,15 +404,15 @@ async function detail(params, context) {
     const html = await requestText(url);
     const $ = cheerio.load(html);
 
-    const vod_name = normalizeText($("h1.text-overflow, h1").first().text() || $("title").text().split("線上看")[0]);
+    const vod_name = toDisplayText($("h1.text-overflow, h1").first().text() || $("title").text().split("線上看")[0]);
     const vod_pic = absUrl($("meta[property='og:image']").attr("content") || $(".details-pic .video-pic").attr("style")?.match(/url\(([^)]+)\)/)?.[1] || $("img").first().attr("src") || "");
-    const vod_content = normalizeText($(".switch-box .text, .details-content .text, .details-content, .detail-sketch").first().text() || $("meta[name='description']").attr("content") || "");
+    const vod_content = toDisplayText($(".switch-box .text, .details-content .text, .details-content, .detail-sketch").first().text() || $("meta[name='description']").attr("content") || "");
     const vod_remarks = pickInfo(html, "狀態") || pickInfo(html, "状态");
     const type_name = pickInfo(html, "類別") || pickInfo(html, "类别");
     const vod_year = pickInfo(html, "年代") || pickInfo(html, "年份");
     const vod_area = pickInfo(html, "國家/地區") || pickInfo(html, "国家/地区");
-    const vod_actor = normalizeText($("li:contains('主演') a").map((_, el) => $(el).text()).get().join(" / "));
-    const vod_director = normalizeText($("li:contains('導演') a, li:contains('导演') a").map((_, el) => $(el).text()).get().join(" / "));
+    const vod_actor = toDisplayText($("li:contains('主演') a").map((_, el) => $(el).text()).get().join(" / "));
+    const vod_director = toDisplayText($("li:contains('導演') a, li:contains('导演') a").map((_, el) => $(el).text()).get().join(" / "));
     const vod_play_sources = parsePlaySources($);
 
     await OmniBox.log("info", `[Gimy剧迷][detail] ${url} 线路=${vod_play_sources.length}`);
@@ -317,12 +446,12 @@ async function search(params, context) {
     const url = `${BASE_URL}/find/-------------.html?wd=${encodeURIComponent(keyword)}&page=${page}`;
     const html = await requestText(url);
     const $ = cheerio.load(html);
-    const rawList = extractCards($);
-    const list = refineSearchResults(rawList, keyword);
-    await OmniBox.log("info", `[Gimy剧迷][search] keyword=${keyword} page=${page} raw=${rawList.length} filtered=${list.length}`);
+    const scope = $(".box-main-content").first();
+    const list = extractCards($, scope);
+    await OmniBox.log("info", `[Gimy剧迷][search] keyword=${keyword} page=${page} scope=.box-main-content list=${list.length}`);
     return {
       page,
-      pagecount: page + (rawList.length >= 20 ? 1 : 0),
+      pagecount: page + (list.length >= 20 ? 1 : 0),
       total: list.length,
       list,
     };
@@ -394,7 +523,7 @@ async function play(params, context) {
           return {
             parse: 0,
             url: mediaUrl,
-            urls: [{ name: playFrom || "直链播放", url: mediaUrl }],
+            urls: [{ name: toDisplayText(playFrom) || "直链播放", url: mediaUrl }],
             header,
             headers: header,
             flag: mediaType || playFrom || "direct",


### PR DESCRIPTION
## 变更内容
- 调整 `影视/采集/Gimy剧迷.js` 搜索逻辑
- 搜索结果不再做本地相关性过滤
- 仅抓取 `class="box-main-content"` 主结果区下的内容

## 原因
此前本地过滤可能误杀站点已返回的有效结果，也容易把搜索页非主结果区的内容混进来。当前改为仅依赖站点搜索页主结果容器，减少误判与噪音。

## 已验证
- `node --check 影视/采集/Gimy剧迷.js`

## 说明
- 本次仅提交 `Gimy剧迷.js` 的搜索范围调整，不包含其他未跟踪文件
