### PR TITLE
feat(影巢): 支持环境变量控制多线路代理

### DIFF
--- a/影视/网盘/影巢.js
+++ b/影视/网盘/影巢.js
@@ -2,7 +2,7 @@
 // @author lampon
 // @description
 // @dependencies axios
-// @version 1.0.0
+// @version 1.1.0
 // @downloadURL https://gh-proxy.org/https://github.com/Silent1566/OmniBox-Spider/raw/refs/heads/main/影视/网盘/影巢.js
 
 const OmniBox = require("omnibox_sdk");
@@ -47,6 +47,21 @@ const HDHIVE_PROXY_URL = process.env.HDHIVE_PROXY_URL || "";
 const PANCHECK_API = process.env.PANCHECK_API || "";
 const PANCHECK_ENABLED = true;
 const PANCHECK_PLATFORMS = process.env.PANCHECK_PLATFORMS || "quark";
+// 读取环境变量：支持多个网盘类型，用分号分割；仅这些网盘类型启用多线路
+const DRIVE_TYPE_CONFIG = (process.env.DRIVE_TYPE_CONFIG || "quark;uc")
+  .split(";")
+  .map((t) => t.trim().toLowerCase())
+  .filter(Boolean);
+// 读取环境变量：线路名称和顺序，用分号分割
+const SOURCE_NAMES_CONFIG = (process.env.SOURCE_NAMES_CONFIG || "本地代理;服务端代理;直连")
+  .split(";")
+  .map((s) => s.trim())
+  .filter(Boolean);
+// 读取环境变量：详情页播放线路的网盘排序顺序。仅作用于 detail() 里的播放线路。
+const DRIVE_ORDER = (process.env.DRIVE_ORDER || "baidu;tianyi;quark;uc;115;xunlei;ali;123pan")
+  .split(";")
+  .map((s) => s.trim().toLowerCase())
+  .filter(Boolean);
 // ==================== 配置区域结束 ====================
 
 let tmdbKeyCache = "";
@@ -250,6 +265,36 @@ function asInt(v, d = 0) {
 
 function getTypeNameByMediaType(mediaType) {
   return mediaType === "movie" ? "电影资源" : "剧集资源";
+}
+
+function inferDriveTypeFromSourceName(name = "") {
+  const raw = String(name || "").toLowerCase();
+  if (raw.includes("百度")) return "baidu";
+  if (raw.includes("天翼")) return "tianyi";
+  if (raw.includes("夸克")) return "quark";
+  if (raw === "uc" || raw.includes("uc")) return "uc";
+  if (raw.includes("115")) return "115";
+  if (raw.includes("迅雷")) return "xunlei";
+  if (raw.includes("阿里")) return "ali";
+  if (raw.includes("123")) return "123pan";
+  return raw;
+}
+
+function sortPlaySourcesByDriveOrder(playSources = []) {
+  if (!Array.isArray(playSources) || playSources.length <= 1 || DRIVE_ORDER.length === 0) {
+    return playSources;
+  }
+  const orderMap = new Map(DRIVE_ORDER.map((name, index) => [name, index]));
+  return [...playSources].sort((a, b) => {
+    const aBase = String(a?.baseSourceName || a?.name || "");
+    const bBase = String(b?.baseSourceName || b?.name || "");
+    const aType = inferDriveTypeFromSourceName(aBase);
+    const bType = inferDriveTypeFromSourceName(bBase);
+    const aOrder = orderMap.has(aType) ? orderMap.get(aType) : Number.MAX_SAFE_INTEGER;
+    const bOrder = orderMap.has(bType) ? orderMap.get(bType) : Number.MAX_SAFE_INTEGER;
+    if (aOrder !== bOrder) return aOrder - bOrder;
+    return 0;
+  });
 }
 
 function isVideoFile(file) {
@@ -1336,14 +1381,14 @@ async function detail(params, context) {
 
     const source = safeString(params?.source || "");
     let sourceNames = [sourceName];
-    if (driveInfo?.driveType === "quark" || driveInfo?.driveType === "uc") {
-      sourceNames = ["服务端代理", "本地代理", "直连"];
+    if (DRIVE_TYPE_CONFIG.includes(String(driveInfo?.driveType || "").toLowerCase())) {
+      sourceNames = [...SOURCE_NAMES_CONFIG];
       if (source === "web") {
         sourceNames = sourceNames.filter((name) => name !== "本地代理");
       }
     }
 
-    const playSources = [];
+    let playSources = [];
     for (const lineName of sourceNames) {
       const episodes = [];
       for (const file of allVideoFiles) {
@@ -1417,11 +1462,24 @@ async function detail(params, context) {
       }
 
       if (episodes.length > 0) {
+        const baseLineName = sourceName;
+        const finalLineName =
+          DRIVE_TYPE_CONFIG.includes(String(driveInfo?.driveType || "").toLowerCase())
+            ? `${baseLineName}-${lineName}`
+            : baseLineName;
         playSources.push({
-          name: lineName,
+          name: finalLineName,
+          baseSourceName: baseLineName,
           episodes,
         });
       }
+    }
+
+    if (playSources.length > 1 && DRIVE_ORDER.length > 0) {
+      playSources = sortPlaySourcesByDriveOrder(playSources).map((item) => ({
+        name: item.name,
+        episodes: item.episodes,
+      }));
     }
 
     let tmdbTitle = payload.title || scrapeData?.title || "";
@@ -1560,10 +1618,19 @@ async function play(params, context) {
       );
     }
 
+    let routeType = safeString(flag);
+    if (routeType && routeType.includes("-")) {
+      const parts = routeType.split("-");
+      routeType = safeString(parts[parts.length - 1]);
+    }
+    if (!routeType) {
+      routeType = safeString(params?.source) === "web" ? "服务端代理" : "直连";
+    }
+
     const playInfo = await OmniBox.getDriveVideoPlayInfo(
       shareURL,
       fileId,
-      "服务端代理",
+      routeType,
     );
     if (
       !playInfo ||

--- a/影视/网盘/影巢.js
+++ b/影视/网盘/影巢.js
@@ -2,7 +2,7 @@
 // @author lampon
 // @description
 // @dependencies axios
-// @version 1.1.0
+// @version 1.1.2
 // @downloadURL https://gh-proxy.org/https://github.com/Silent1566/OmniBox-Spider/raw/refs/heads/main/影视/网盘/影巢.js
 
 const OmniBox = require("omnibox_sdk");
@@ -295,6 +295,61 @@ function sortPlaySourcesByDriveOrder(playSources = []) {
     if (aOrder !== bOrder) return aOrder - bOrder;
     return 0;
   });
+}
+
+function normalizeEpisodeKeyword(value) {
+  return safeString(value)
+    .toLowerCase()
+    .replace(/\s+/g, "")
+    .replace(/[【】\[\]()（）._\-]/g, "");
+}
+
+function pickBestEpisodeFile(files = [], episodeName = "") {
+  if (!Array.isArray(files) || files.length === 0) return null;
+  const keyword = normalizeEpisodeKeyword(episodeName);
+  if (keyword) {
+    const matched = files.find((file) =>
+      normalizeEpisodeKeyword(file?.episodeName || file?.file_name).includes(keyword),
+    );
+    if (matched) return matched;
+  }
+  return files[0] || null;
+}
+
+function sanitizeLegacyPlayText(value) {
+  return safeString(value).replace(/[#$]/g, " ").trim();
+}
+
+function buildLegacyPlayFields(playSources = []) {
+  if (!Array.isArray(playSources) || playSources.length === 0) {
+    return { vod_play_from: "", vod_play_url: "" };
+  }
+
+  const vodPlayFrom = [];
+  const vodPlayUrl = [];
+
+  for (const source of playSources) {
+    const sourceName = sanitizeLegacyPlayText(source?.name || "默认线路") || "默认线路";
+    const episodes = Array.isArray(source?.episodes) ? source.episodes : [];
+    const episodeItems = episodes
+      .map((episode, index) => {
+        const epName = sanitizeLegacyPlayText(episode?.name || episode?.episodeName || `第${index + 1}集`) || `第${index + 1}集`;
+        const playId = safeString(episode?.playId || "");
+        if (!playId) return "";
+        return `${epName}$${playId}`;
+      })
+      .filter(Boolean);
+
+    if (episodeItems.length > 0) {
+      vodPlayFrom.push(sourceName);
+      vodPlayUrl.push(episodeItems.join("#"));
+    }
+  }
+
+  return {
+    vod_play_from: vodPlayFrom.join("$$$"),
+    vod_play_url: vodPlayUrl.join("$$$"),
+  };
 }
 
 function isVideoFile(file) {
@@ -1466,7 +1521,7 @@ async function detail(params, context) {
         const finalLineName =
           DRIVE_TYPE_CONFIG.includes(String(driveInfo?.driveType || "").toLowerCase())
             ? `${baseLineName}-${lineName}`
-            : baseLineName;
+            : `${baseLineName}-网盘线路`;
         playSources.push({
           name: finalLineName,
           baseSourceName: baseLineName,
@@ -1530,6 +1585,8 @@ async function detail(params, context) {
       );
     }
 
+    const legacyPlayFields = buildLegacyPlayFields(playSources);
+
     return {
       list: [
         {
@@ -1542,6 +1599,8 @@ async function detail(params, context) {
           vod_content:
             tmdbOverview || `HDHive 资源，共 ${episodes.length} 个视频文件`,
           vod_play_sources: playSources,
+          vod_play_from: legacyPlayFields.vod_play_from,
+          vod_play_url: legacyPlayFields.vod_play_url,
           vod_douban_score: tmdbScore,
         },
       ],
@@ -1562,13 +1621,36 @@ async function play(params, context) {
     if (!playId) throw new Error("playId 不能为空");
 
     const parts = playId.split("|");
-    if (parts.length < 2) throw new Error(`playId 格式错误: ${playId}`);
-    const shareURL = safeString(parts[0]);
-    const fileId = safeString(parts[1]);
+    let shareURL = safeString(parts[0]);
+    let fileId = safeString(parts[1]);
     // 第三段可能是 detail 透传过来的原始 vodId（JSON字符串）
-    const rawVodIdFromPlayId =
+    let rawVodIdFromPlayId =
       parts.length >= 3 ? safeString(parts.slice(2).join("|")) : "";
-    if (!shareURL || !fileId) throw new Error("分享链接或文件ID为空");
+
+    if (!shareURL) throw new Error("分享链接为空");
+
+    if (!fileId) {
+      await OmniBox.log(
+        "warn",
+        `tmdb.js play 收到缺少 fileId 的 playId，尝试按 shareURL 兜底解析: ${playId}`,
+      );
+      const rootList = await OmniBox.getDriveFileList(shareURL, "0");
+      const allVideoFiles = await getAllVideoFiles(shareURL, rootList?.files || []);
+      const enrichedFiles = allVideoFiles.map((file) => ({
+        ...file,
+        fileId: safeString(file?.fid || file?.file_id),
+        episodeName: safeString(file?.episodeName || params?.episodeName || ""),
+      })).filter((file) => file.fileId);
+      const matchedFile = pickBestEpisodeFile(enrichedFiles, params?.episodeName || "");
+      if (!matchedFile || !matchedFile.fileId) {
+        throw new Error(`playId 缺少文件ID且兜底未找到可播放文件: ${playId}`);
+      }
+      fileId = safeString(matchedFile.fileId);
+      await OmniBox.log(
+        "info",
+        `tmdb.js play 兜底命中文件: ${safeString(matchedFile.file_name)} -> ${fileId}`,
+      );
+    }
 
     // 参考 pansou.js：匹配元数据用于弹幕和历史写入
     let danmakuList = [];


### PR DESCRIPTION
## 变更说明
- 同步参考 `影视/网盘/木偶.js`，给 `影视/网盘/影巢.js` 补上基于环境变量的多线路代理控制
- 新增 `DRIVE_TYPE_CONFIG`，仅对指定网盘类型启用多线路
- 新增 `SOURCE_NAMES_CONFIG`，支持通过环境变量控制 `本地代理 / 服务端代理 / 直连` 的线路名称与顺序
- 新增 `DRIVE_ORDER`，用于详情页线路排序
- `play()` 改为根据线路 flag / `params.source` 动态选择 routeType，不再写死 `服务端代理`
- 版本号从 `1.0.0` 升到 `1.1.0`

## 验证
- `node --check 影视/网盘/影巢.js`
