### PR TITLE
fix: 优化修罗影视验证码识别与会话缓存

### DIFF
--- a/影视/采集/修罗影视.js
+++ b/影视/采集/修罗影视.js
@@ -2,7 +2,7 @@
 // @author 
 // @description 刮削：支持，弹幕：支持，嗅探：支持
 // @dependencies: axios, cheerio, crypto-js
-// @version 1.0.4
+// @version 1.0.19
 // @downloadURL https://gh-proxy.org/https://github.com/Silent1566/OmniBox-Spider/raw/refs/heads/main/影视/采集/修罗影视.js
 
 /**
@@ -25,18 +25,44 @@ const cheerio = require("cheerio");
 const OmniBox = require("omnibox_sdk");
 const https = require("https");
 
-// ========== 全局配置 ==========
-const HOST = "https://www.xlys02.com";
-const UA = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/144.0.0.0 Safari/537.36";
-const MOBILE_UA = "Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.1 Mobile/15E148 Safari/604.1";
+// ==================== 配置区域开始 ====================
+// 弹幕接口地址。未配置时不启用弹幕补充。
 const DANMU_API = process.env.DANMU_API || "";
+// 修罗专用 ddddocr 基础地址。若配置该项，优先按 ddddocr 风格处理。
+const RAW_XIULUO_DDDDOCR_API = String(process.env.XIULUO_DDDDOCR_API || "").trim();
+// 修罗专用普通 OCR 基础地址。仅在未配置 ddddocr 地址时参与兜底。
+const RAW_XIULUO_OCR_API = String(process.env.XIULUO_OCR_API || "").trim();
+// 通用 ddddocr 基础地址。作为修罗专用 ddddocr 地址的后备。
+const RAW_DDDDOCR_API = String(process.env.DDDDOCR_API || "").trim();
+// 通用 OCR 基础地址。作为修罗专用普通 OCR 地址的后备。
+const RAW_OCR_API = String(process.env.OCR_API || "").trim();
+// OCR 识别接口自定义路径。留空时自动按接口类型推断。
+const EXTERNAL_OCR_PATH = String(process.env.XIULUO_DDDDOCR_PATH || process.env.XIULUO_OCR_PATH || "").trim();
 
-// 会话缓存(20分钟)
+// 最终生效的外部 OCR 基础地址。优先级：修罗专用 ddddocr > 修罗专用 OCR > 通用 ddddocr > 通用 OCR。
+const EXTERNAL_OCR_API = String(RAW_XIULUO_DDDDOCR_API || RAW_XIULUO_OCR_API || RAW_DDDDOCR_API || RAW_OCR_API || "").trim();
+// OCR 接口类型标记：ddddocr 或普通 ocr，用于自动推断接口路径。
+const OCR_API_KIND = (RAW_XIULUO_DDDDOCR_API || RAW_DDDDOCR_API) ? "ddddocr" : ((RAW_XIULUO_OCR_API || RAW_OCR_API) ? "ocr" : "");
+// 默认公共 OCR 兜底接口。当自定义 OCR 失败时回退到该接口。
+const DEFAULT_OCR_API = "https://api.nn.ci/ocr/b64/json";
+// 搜索会话的 SDK 标准缓存键。
+const SESSION_CACHE_KEY = "xiuluo:search-cookie";
+// 搜索会话缓存时长：30 分钟。
+const SESSION_TTL = 30 * 60 * 1000;
+
+// 站点主域名。
+const HOST = "https://www.xlys02.com";
+// 桌面端请求 User-Agent。
+const UA = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/144.0.0.0 Safari/537.36";
+// 移动端请求 User-Agent。搜索与验证码链路优先使用该 UA。
+const MOBILE_UA = "Mozilla/5.0 (iPhone; CPU iPhone OS 18_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.1 Mobile/15E148 Safari/604.1";
+
+// 进程内搜索会话镜像缓存。优先配合 SDK 缓存一起使用，减少重复读取。
 let SESSION_CACHE = {
     cookie: null,
     expire: 0
 };
-const SESSION_TTL = 20 * 60 * 1000;
+// ==================== 配置区域结束 ====================
 
 /**
  * 创建 HTTPS Agent (忽略 SSL 证书验证)
@@ -179,6 +205,178 @@ const requestPost = async (url, data, options = {}) => {
     }
 };
 
+const resolveExternalOcrCandidates = () => {
+    const normalizedBase = EXTERNAL_OCR_API.replace(/\/$/, "");
+    if (!normalizedBase) return [DEFAULT_OCR_API];
+    const lower = normalizedBase.toLowerCase();
+    const looksLikeFullEndpoint = /\/(ocr|slide|det)(\/|$)|\/json(\/|$)/.test(lower);
+    if (looksLikeFullEndpoint) {
+        return [...new Set([normalizedBase, DEFAULT_OCR_API].filter(Boolean))];
+    }
+
+    const hasExplicitPath = !!EXTERNAL_OCR_PATH;
+    const inferredPaths = hasExplicitPath
+        ? [EXTERNAL_OCR_PATH]
+        : (OCR_API_KIND === "ddddocr" ? ["/ocr"] : ["/ocr/b64/json"]);
+    const candidates = [];
+    for (const path of inferredPaths) {
+        const normalizedPath = String(path || "").startsWith("/") ? String(path || "") : `/${String(path || "")}`;
+        candidates.push(`${normalizedBase}${normalizedPath}`);
+    }
+    candidates.push(normalizedBase, DEFAULT_OCR_API);
+    return [...new Set(candidates.filter(Boolean))];
+};
+
+const hasVerifyOperator = (raw) => /[+\-xX×/]/.test(String(raw || ""));
+
+const normalizePureDigitsVerifyExpr = (raw) => {
+    const digits = String(raw || "").replace(/\D/g, "");
+    if (digits.length === 4) {
+        return `${digits.slice(0, 2)}-${digits.slice(2)}`;
+    }
+    if (digits.length === 5) {
+        return `${digits.slice(0, 2)}-${digits.slice(3)}`;
+    }
+    return "";
+};
+
+const requestVerifyCodeByDefaultApi = async (b64) => {
+    try {
+        logInfo("🧾 OCR请求", { url: DEFAULT_OCR_API });
+        const ocrRes = await axiosInstance.post(DEFAULT_OCR_API, b64, {
+            headers: { "User-Agent": MOBILE_UA },
+            timeout: 8000,
+        });
+        const data = ocrRes.data || {};
+        const raw = String(
+            data?.result
+            || data?.data?.code
+            || data?.data?.result
+            || data?.data?.text
+            || data?.data?.ocr_text
+            || data?.code
+            || data?.text
+            || data?.ocr_text
+            || ""
+        ).trim();
+        logInfo("🧾 OCR识别", { url: DEFAULT_OCR_API, raw });
+        return raw;
+    } catch (e) {
+        logError(`⚠ OCR异常 @ ${DEFAULT_OCR_API}`, e);
+        return "";
+    }
+};
+
+const requestVerifyCodeByOcr = async (b64) => {
+    const candidates = resolveExternalOcrCandidates();
+    let lastError = null;
+    let fallbackRaw = "";
+    for (const url of candidates) {
+        try {
+            logInfo("🧾 OCR请求", { url });
+            const lower = String(url || "").toLowerCase();
+            const isDefaultApi = url === DEFAULT_OCR_API;
+            const isDdddocrTextApi = /\/ocr(\/|$)/.test(lower) && !/\/b64\/json(\/|$)/.test(lower);
+            const payload = isDefaultApi
+                ? b64
+                : (isDdddocrTextApi
+                    ? { data: `data:image/png;base64,${b64}`, mode: 1, range: 7 }
+                    : { image: b64, img: b64, base64: b64, data: `data:image/png;base64,${b64}` });
+            const headers = { "User-Agent": MOBILE_UA };
+            if (!isDefaultApi) headers["Content-Type"] = "application/json";
+            const ocrRes = await axiosInstance.post(url, payload, { headers, timeout: 8000 });
+            const data = ocrRes.data || {};
+            const raw = String(
+                data?.result
+                || data?.data?.code
+                || data?.data?.result
+                || data?.data?.text
+                || data?.data?.ocr_text
+                || data?.code
+                || data?.text
+                || data?.ocr_text
+                || ""
+            ).trim().split("=")[0].trim();
+            logInfo("🧾 OCR识别", { url, raw });
+            if (!raw) continue;
+            if (hasVerifyOperator(raw)) return raw;
+            const normalizedExpr = normalizePureDigitsVerifyExpr(raw);
+            if (normalizedExpr) {
+                logInfo("🧮 纯数字验证码改写", { raw, normalizedExpr });
+                return normalizedExpr;
+            }
+            if (isDefaultApi) {
+                logInfo("⚠ 默认OCR结果不含运算符且无法改写，视为失败", { raw });
+                fallbackRaw = raw;
+                continue;
+            }
+            logInfo("⚠ OCR结果不含运算符且无法改写，尝试默认OCR兜底", { url, raw });
+            const defaultRaw = await requestVerifyCodeByDefaultApi(b64);
+            if (defaultRaw && hasVerifyOperator(defaultRaw)) return defaultRaw;
+            const normalizedDefaultExpr = normalizePureDigitsVerifyExpr(defaultRaw);
+            if (normalizedDefaultExpr) {
+                logInfo("🧮 默认OCR纯数字改写", { raw: defaultRaw, normalizedExpr: normalizedDefaultExpr });
+                return normalizedDefaultExpr;
+            }
+            fallbackRaw = defaultRaw || raw;
+            break;
+        } catch (e) {
+            lastError = e;
+            logError(`⚠ OCR异常 @ ${url}`, e);
+        }
+    }
+    if (fallbackRaw && !hasVerifyOperator(fallbackRaw)) {
+        return "";
+    }
+    if (lastError) throw lastError;
+    return "";
+};
+
+const loadSessionCache = async () => {
+    const now = Date.now();
+    if (SESSION_CACHE.cookie && now < SESSION_CACHE.expire) {
+        return SESSION_CACHE.cookie;
+    }
+    try {
+        const cached = await OmniBox.getCache(SESSION_CACHE_KEY);
+        if (!cached) return "";
+        const parsed = typeof cached === "string" ? JSON.parse(cached) : cached;
+        const cookie = String(parsed?.cookie || "").trim();
+        const expire = Number(parsed?.expire || 0);
+        if (cookie && expire > now) {
+            SESSION_CACHE.cookie = cookie;
+            SESSION_CACHE.expire = expire;
+            return cookie;
+        }
+    } catch (e) {
+        logError("读取SDK会话缓存失败", e);
+    }
+    return "";
+};
+
+const saveSessionCache = async (cookie) => {
+    const value = String(cookie || "").trim();
+    if (!value) return;
+    const expire = Date.now() + SESSION_TTL;
+    SESSION_CACHE.cookie = value;
+    SESSION_CACHE.expire = expire;
+    try {
+        await OmniBox.setCache(SESSION_CACHE_KEY, JSON.stringify({ cookie: value, expire }), Math.ceil(SESSION_TTL / 1000));
+    } catch (e) {
+        logError("写入SDK会话缓存失败", e);
+    }
+};
+
+const clearSessionCache = async () => {
+    SESSION_CACHE.cookie = null;
+    SESSION_CACHE.expire = 0;
+    try {
+        await OmniBox.setCache(SESSION_CACHE_KEY, JSON.stringify({ cookie: "", expire: 0 }), 1);
+    } catch (e) {
+        logError("清理SDK会话缓存失败", e);
+    }
+};
+
 /**
  * 通过API进行聚合搜索(验证码失败兜底)
  */
@@ -269,16 +467,25 @@ const calcVerifyCode = (text) => {
     if (!text) return null;
     let exp = text.replace(/\s/g, "").replace("=", "");
     exp = exp.replace(/[xX×]/g, "*").replace(/-/g, "-");
-    const match = exp.match(/^(\d+)([\+\-\*])(\d+)$/);
+    const match = exp.match(/^(\d+)([\+\-\*\/])(\d+)$/);
     if (!match) return null;
     const a = parseInt(match[1], 10);
     const op = match[2];
     const b = parseInt(match[3], 10);
     switch (op) {
-        case "+": return a + b;
-        case "-": return a - b;
-        case "*": return a * b;
-        default: return null;
+        case "+":
+            return a + b;
+        case "-":
+            return a - b;
+        case "*": {
+            const result = a * b;
+            return result > 100 ? (a + b) : result;
+        }
+        case "/":
+            if (!b) return null;
+            return Math.floor(a / b);
+        default:
+            return null;
     }
 };
 
@@ -701,32 +908,42 @@ async function search(params) {
         return { list: [] };
     }
 
-    const now = Date.now();
+    const cachedCookie = await loadSessionCache();
 
-    // 优先使用缓存
-    if (SESSION_CACHE.cookie && now < SESSION_CACHE.expire) {
-        logInfo("♻ 使用缓存会话");
+    // 优先使用 SDK 缓存会话
+    if (cachedCookie) {
+        logInfo("♻ 使用SDK缓存会话");
         try {
-            const fastUrl = `${HOST}/search/${encodeURIComponent(keyword)}/${pg}`;
+            const fastUrl = `${HOST}/search/${encodeURIComponent(keyword)}`;
+            const fastReferer = `${HOST}/search/${encodeURIComponent(keyword)}?code=0`;
             const fastRes = await axiosInstance.get(fastUrl, {
                 headers: {
-                    "User-Agent": MOBILE_UA,
-                    "Cookie": SESSION_CACHE.cookie
+                    "User-Agent": UA,
+                    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7",
+                    "Accept-Language": "zh-CN,zh;q=0.9,en;q=0.8,en-GB;q=0.7,en-US;q=0.6",
+                    "Upgrade-Insecure-Requests": "1",
+                    "Sec-Fetch-Dest": "document",
+                    "Sec-Fetch-Mode": "navigate",
+                    "Sec-Fetch-Site": "same-origin",
+                    "Sec-Fetch-User": "?1",
+                    "Cookie": cachedCookie,
+                    "Referer": fastReferer,
                 }
             });
             const result = await parseSearch(fastRes.data, pg, keyword);
-            if (result.list.length > 0) {
-                logInfo("✅ 缓存会话有效");
+            if (result.list.length > 0 || !(String(fastRes.data || "").includes("verifyCode") || String(fastRes.data || "").includes("验证码"))) {
+                logInfo("✅ SDK缓存会话有效");
                 return result;
             }
-            logInfo("⚠ 缓存失效，重新验证");
+            logInfo("⚠ SDK缓存失效，重新验证");
+            await clearSessionCache();
         } catch (e) {
-            logError("⚠ 缓存请求异常", e);
+            logError("⚠ SDK缓存请求异常", e);
+            await clearSessionCache();
         }
     }
 
     logInfo(`🔍 开始搜索: ${keyword}`);
-    const ocrApi = "https://api.nn.ci/ocr/b64/json";
     const MAX_FLOW_RETRY = 3;
 
     try {
@@ -760,12 +977,8 @@ async function search(params) {
                         }
                     );
                     const b64 = Buffer.from(imgRes.data).toString("base64");
-                    const ocrRes = await axiosInstance.post(ocrApi, b64, {
-                        headers: { "User-Agent": MOBILE_UA },
-                        timeout: 8000
-                    });
-                    const raw = ocrRes.data?.result?.trim();
-                    logInfo(`🧾 OCR识别: ${raw}`);
+                    logInfo("🖼 验证码Base64", { preview: b64.slice(0, 160), length: b64.length, dataUrl: `data:image/png;base64,${b64}` });
+                    const raw = await requestVerifyCodeByOcr(b64);
                     verifyCode = calcVerifyCode(raw);
                     if (verifyCode !== null) {
                         logInfo(`✅ 验证码计算结果: ${verifyCode}`);
@@ -802,9 +1015,8 @@ async function search(params) {
 
             const result = await parseSearch(html, pg, keyword);
             if (result.list.length > 0) {
-                SESSION_CACHE.cookie = finalCookie;
-                SESSION_CACHE.expire = Date.now() + SESSION_TTL;
-                logInfo("💾 会话缓存成功(20分钟)");
+                await saveSessionCache(finalCookie);
+                logInfo("💾 会话缓存成功(30分钟)");
                 logInfo(`🎯 搜索成功: ${result.list.length}条`);
                 return result;
             }


### PR DESCRIPTION
## 变更内容
- 优化 `影视/采集/修罗影视.js` 的验证码识别与搜索会话流程
- 新增 OCR 配置入口并支持自动识别 endpoint
- ddddocr 文本识别优先走 `/ocr`，并为 `/ocr` 请求补充：
  - `mode: 1`
  - `range: 7`
- OCR 结果只保留 `=` 号前半段再参与计算
- 纯数字验证码补规则：
  - 4 位数字：前两位减后两位
  - 5 位数字：丢弃第 3 位后，前两位减后两位
- 乘法结果大于 100 时改用加法结果
- OCR 结果若不含 `+ - x /`，则再尝试默认 `https://api.nn.ci/ocr/b64/json`；两边都不满足则直接失败
- 搜索会话 cookie 改为 SDK 标准缓存 30 分钟，优先直用缓存，无效再重新获取
- 已将配置区域整理为带开始/结束分隔符、环境变量前置、并补全注释

## 验证
- `node --check 影视/采集/修罗影视.js`

## 说明
- 本次仅纳入 `影视/采集/修罗影视.js`
- 未带入仓库中其他 `.tmp-*`、缓存目录或无关未跟踪文件
