### PR TITLE
fix: 修复木偶 playId 透传与弹幕日志链路

### DIFF
--- a/影视/网盘/木偶.js
+++ b/影视/网盘/木偶.js
@@ -2,7 +2,7 @@
 // @author
 // @description 刮削：支持，弹幕：支持，嗅探：支持
 // @dependencies: axios, cheerio
-// @version 1.2.12
+// @version 1.2.14
 // @downloadURL https://gh-proxy.org/https://github.com/Silent1566/OmniBox-Spider/raw/refs/heads/main/影视/网盘/木偶.js
 
 // 引入 OmniBox SDK
@@ -1383,9 +1383,25 @@ async function play(params, context) {
       throw new Error("播放参数格式错误,应为:分享链接|文件ID");
     }
 
-    const shareURL = idParts[0] || "";
-    const fileId = idParts[1] || "";
-    const videoId = idParts[2] || "";
+    let playMeta = {};
+    let coreParts = [...idParts];
+    if (coreParts.length >= 4) {
+      const possibleMeta = coreParts[coreParts.length - 1] || "";
+      try {
+        playMeta = decodeMeta(possibleMeta);
+        if (playMeta && typeof playMeta === "object" && (playMeta.v || playMeta.e || playMeta.fid || playMeta.sid)) {
+          coreParts = coreParts.slice(0, -1);
+        } else {
+          playMeta = {};
+        }
+      } catch (_) {
+        playMeta = {};
+      }
+    }
+
+    const shareURL = coreParts[0] || "";
+    const fileId = coreParts[1] || "";
+    const videoId = playMeta.sid || coreParts[2] || "";
 
     if (!shareURL || !fileId) {
       throw new Error("分享链接或文件ID不能为空");
@@ -1404,7 +1420,7 @@ async function play(params, context) {
         scrapeTitle: "",
         scrapePic: "",
         episodeNumber: null,
-        episodeName: params.episodeName || "",
+        episodeName: params.episodeName || playMeta.e || "",
       };
 
       if (!videoId) return result;
@@ -1412,12 +1428,17 @@ async function play(params, context) {
       try {
         const metadata = await OmniBox.getScrapeMetadata(videoId);
         if (!metadata || !metadata.scrapeData || !Array.isArray(metadata.videoMappings)) {
+          OmniBox.log("info", `木偶 play 弹幕匹配跳过: metadata 不完整, videoId=${videoId}`);
           return result;
         }
 
+        OmniBox.log("info", `木偶 play 弹幕元数据读取成功: videoId=${videoId}, mappings=${metadata.videoMappings.length}, scrapeType=${metadata.scrapeType || "unknown"}`);
+
         const formattedFileId = `${shareURL}|${fileId}|${videoId}`;
+        OmniBox.log("info", `木偶 play 弹幕匹配 formattedFileId=${formattedFileId}`);
         const matchedMapping = metadata.videoMappings.find((mapping) => mapping && mapping.fileId === formattedFileId);
         if (!matchedMapping) {
+          OmniBox.log("info", `木偶 play 弹幕匹配未命中 mapping: formattedFileId=${formattedFileId}`);
           return result;
         }
 
@@ -1447,15 +1468,19 @@ async function play(params, context) {
         }
 
         if (fileName) {
-          OmniBox.log("info", `生成fileName用于弹幕匹配: ${fileName}`);
+          OmniBox.log("info", `木偶 play 生成fileName用于弹幕匹配: ${fileName}`);
           const matchedDanmaku = await OmniBox.getDanmakuByFileName(fileName);
-          if (Array.isArray(matchedDanmaku) && matchedDanmaku.length > 0) {
+          const count = Array.isArray(matchedDanmaku) ? matchedDanmaku.length : 0;
+          OmniBox.log("info", `木偶 play 弹幕匹配结果: fileName=${fileName}, count=${count}`);
+          if (count > 0) {
             result.danmakuList = matchedDanmaku;
-            OmniBox.log("info", `弹幕匹配成功,找到 ${matchedDanmaku.length} 条弹幕`);
+            OmniBox.log("info", `木偶 play 弹幕匹配成功,找到 ${count} 条弹幕`);
           }
+        } else {
+          OmniBox.log("info", `木偶 play 弹幕匹配跳过: fileName 为空, formattedFileId=${formattedFileId}`);
         }
       } catch (error) {
-        OmniBox.log("warn", `弹幕匹配失败: ${error.message}`);
+        OmniBox.log("warn", `木偶 play 弹幕匹配失败: ${error.message}`);
       }
 
       return result;


### PR DESCRIPTION
## 变更内容
- 修复 `影视/网盘/木偶.js` 的 playId 透传解析与弹幕链路
- `play()` 先识别并剥离 playId 末尾透传的 Base64 元数据
- 优先使用 `playMeta.sid` 作为真正的 `videoId`
- 优先使用 `playMeta.e` 作为默认 `episodeName`
- 补齐弹幕日志，明确打印：
  - metadata 是否完整
  - mapping 是否命中
  - formattedFileId
  - 最终 fileName
  - danmaku count

## 验证
- `node --check 影视/网盘/木偶.js`

## 说明
- 本次仅纳入 `影视/网盘/木偶.js`
- 未带入仓库中其他未跟踪文件或无关改动
