### PR TITLE
fix: 同步网盘源透传元数据与 play 解析修复

### DIFF
--- a/影视/网盘/二小.js
+++ b/影视/网盘/二小.js
@@ -2,7 +2,7 @@
 // @author
 // @description 刮削：支持，弹幕：支持，嗅探：支持
 // @dependencies: axios, cheerio
-// @version 1.2.2
+// @version 1.2.3
 // @downloadURL https://gh-proxy.org/https://github.com/Silent1566/OmniBox-Spider/raw/refs/heads/main/影视/网盘/二小.js
 
 // 引入 OmniBox SDK
@@ -1165,6 +1165,9 @@ async function detail(params, context) {
 
           const normalizedOriginalEpisodeName = normalizeEpisodeName(file.file_name || fileName);
           const playMeta = encodePlayMeta({
+            sid: videoId,
+            fid: fileId ? `${shareURL}|${fileId}` : "",
+            v: vodName || "",
             t: vodName,
             e: normalizedOriginalEpisodeName,
           });
@@ -1378,9 +1381,25 @@ async function play(params, context) {
       throw new Error("播放参数格式错误,应为:分享链接|文件ID");
     }
 
-    const shareURL = idParts[0] || "";
-    const fileId = idParts[1] || "";
-    const videoId = idParts[2] || "";
+    let playMeta = {};
+    let coreParts = [...idParts];
+    if (coreParts.length >= 3) {
+      const possibleMeta = coreParts[coreParts.length - 1] || "";
+      try {
+        playMeta = decodePlayMeta(possibleMeta);
+        if (playMeta && typeof playMeta === "object" && (playMeta.v || playMeta.e || playMeta.fid || playMeta.sid || playMeta.t)) {
+          coreParts = coreParts.slice(0, -1);
+        } else {
+          playMeta = {};
+        }
+      } catch (_) {
+        playMeta = {};
+      }
+    }
+
+    const shareURL = coreParts[0] || "";
+    const fileId = coreParts[1] || "";
+    const videoId = playMeta.sid || coreParts[2] || "";
 
     if (!shareURL || !fileId) {
       throw new Error("分享链接或文件ID不能为空");
@@ -1399,7 +1418,7 @@ async function play(params, context) {
         scrapeTitle: "",
         scrapePic: "",
         episodeNumber: null,
-        episodeName: params.episodeName || "",
+        episodeName: params.episodeName || playMeta.e || "",
       };
 
       if (!videoId) return result;

--- a/影视/网盘/快映.js
+++ b/影视/网盘/快映.js
@@ -2,7 +2,7 @@
 // @author 
 // @description 刮削：支持，弹幕：支持，播放记录：支持
 // @dependencies: axios, cheerio
-// @version 1.0.6
+// @version 1.0.7
 // @downloadURL https://gh-proxy.org/https://github.com/Silent1566/OmniBox-Spider/raw/refs/heads/main/影视/网盘/快映.js
 
 // 引入 OmniBox SDK
@@ -1165,6 +1165,9 @@ async function detail(params, context) {
 
           const normalizedOriginalEpisodeName = normalizeEpisodeName(file.file_name || fileName);
           const playMeta = encodePlayMeta({
+            sid: videoId,
+            fid: fileId ? `${shareURL}|${fileId}` : "",
+            v: vodName || "",
             t: vodName,
             e: normalizedOriginalEpisodeName,
           });
@@ -1378,9 +1381,25 @@ async function play(params, context) {
       throw new Error("播放参数格式错误,应为:分享链接|文件ID");
     }
 
-    const shareURL = idParts[0] || "";
-    const fileId = idParts[1] || "";
-    const videoId = idParts[2] || "";
+    let playMeta = {};
+    let coreParts = [...idParts];
+    if (coreParts.length >= 3) {
+      const possibleMeta = coreParts[coreParts.length - 1] || "";
+      try {
+        playMeta = decodePlayMeta(possibleMeta);
+        if (playMeta && typeof playMeta === "object" && (playMeta.v || playMeta.e || playMeta.fid || playMeta.sid || playMeta.t)) {
+          coreParts = coreParts.slice(0, -1);
+        } else {
+          playMeta = {};
+        }
+      } catch (_) {
+        playMeta = {};
+      }
+    }
+
+    const shareURL = coreParts[0] || "";
+    const fileId = coreParts[1] || "";
+    const videoId = playMeta.sid || coreParts[2] || "";
 
     if (!shareURL || !fileId) {
       throw new Error("分享链接或文件ID不能为空");
@@ -1399,7 +1418,7 @@ async function play(params, context) {
         scrapeTitle: "",
         scrapePic: "",
         episodeNumber: null,
-        episodeName: params.episodeName || "",
+        episodeName: params.episodeName || playMeta.e || "",
       };
 
       if (!videoId) return result;

--- a/影视/网盘/欧哥.js
+++ b/影视/网盘/欧哥.js
@@ -2,7 +2,7 @@
 // @author 
 // @description 刮削：支持，弹幕：支持，播放记录：支持
 // @dependencies: axios, cheerio
-// @version 1.0.5
+// @version 1.0.6
 // @downloadURL https://gh-proxy.org/https://github.com/Silent1566/OmniBox-Spider/raw/refs/heads/main/影视/网盘/欧哥.js
 
 // 引入 OmniBox SDK
@@ -1165,6 +1165,9 @@ async function detail(params, context) {
 
           const normalizedOriginalEpisodeName = normalizeEpisodeName(file.file_name || fileName);
           const playMeta = encodePlayMeta({
+            sid: videoId,
+            fid: fileId ? `${shareURL}|${fileId}` : "",
+            v: vodName || "",
             t: vodName,
             e: normalizedOriginalEpisodeName,
           });
@@ -1378,9 +1381,25 @@ async function play(params, context) {
       throw new Error("播放参数格式错误,应为:分享链接|文件ID");
     }
 
-    const shareURL = idParts[0] || "";
-    const fileId = idParts[1] || "";
-    const videoId = idParts[2] || "";
+    let playMeta = {};
+    let coreParts = [...idParts];
+    if (coreParts.length >= 3) {
+      const possibleMeta = coreParts[coreParts.length - 1] || "";
+      try {
+        playMeta = decodePlayMeta(possibleMeta);
+        if (playMeta && typeof playMeta === "object" && (playMeta.v || playMeta.e || playMeta.fid || playMeta.sid || playMeta.t)) {
+          coreParts = coreParts.slice(0, -1);
+        } else {
+          playMeta = {};
+        }
+      } catch (_) {
+        playMeta = {};
+      }
+    }
+
+    const shareURL = coreParts[0] || "";
+    const fileId = coreParts[1] || "";
+    const videoId = playMeta.sid || coreParts[2] || "";
 
     if (!shareURL || !fileId) {
       throw new Error("分享链接或文件ID不能为空");
@@ -1399,7 +1418,7 @@ async function play(params, context) {
         scrapeTitle: "",
         scrapePic: "",
         episodeNumber: null,
-        episodeName: params.episodeName || "",
+        episodeName: params.episodeName || playMeta.e || "",
       };
 
       if (!videoId) return result;

--- a/影视/网盘/至臻.js
+++ b/影视/网盘/至臻.js
@@ -2,7 +2,7 @@
 // @author
 // @description 刮削：支持，弹幕：支持，播放记录：支持
 // @dependencies: axios, cheerio
-// @version 1.0.5
+// @version 1.0.6
 // @downloadURL https://gh-proxy.org/https://github.com/Silent1566/OmniBox-Spider/raw/refs/heads/main/影视/网盘/至臻.js
 
 // 引入 OmniBox SDK
@@ -1165,6 +1165,9 @@ async function detail(params, context) {
 
           const normalizedOriginalEpisodeName = normalizeEpisodeName(file.file_name || fileName);
           const playMeta = encodePlayMeta({
+            sid: videoId,
+            fid: fileId ? `${shareURL}|${fileId}` : "",
+            v: vodName || "",
             t: vodName,
             e: normalizedOriginalEpisodeName,
           });
@@ -1378,9 +1381,25 @@ async function play(params, context) {
       throw new Error("播放参数格式错误,应为:分享链接|文件ID");
     }
 
-    const shareURL = idParts[0] || "";
-    const fileId = idParts[1] || "";
-    const videoId = idParts[2] || "";
+    let playMeta = {};
+    let coreParts = [...idParts];
+    if (coreParts.length >= 3) {
+      const possibleMeta = coreParts[coreParts.length - 1] || "";
+      try {
+        playMeta = decodePlayMeta(possibleMeta);
+        if (playMeta && typeof playMeta === "object" && (playMeta.v || playMeta.e || playMeta.fid || playMeta.sid || playMeta.t)) {
+          coreParts = coreParts.slice(0, -1);
+        } else {
+          playMeta = {};
+        }
+      } catch (_) {
+        playMeta = {};
+      }
+    }
+
+    const shareURL = coreParts[0] || "";
+    const fileId = coreParts[1] || "";
+    const videoId = playMeta.sid || coreParts[2] || "";
 
     if (!shareURL || !fileId) {
       throw new Error("分享链接或文件ID不能为空");
@@ -1399,7 +1418,7 @@ async function play(params, context) {
         scrapeTitle: "",
         scrapePic: "",
         episodeNumber: null,
-        episodeName: params.episodeName || "",
+        episodeName: params.episodeName || playMeta.e || "",
       };
 
       if (!videoId) return result;

--- a/影视/网盘/虎斑.js
+++ b/影视/网盘/虎斑.js
@@ -2,7 +2,7 @@
 // @author 
 // @description 刮削：支持，弹幕：支持，嗅探：支持
 // @dependencies: axios, cheerio
-// @version 1.0.5
+// @version 1.0.6
 // @downloadURL https://gh-proxy.org/https://github.com/Silent1566/OmniBox-Spider/raw/refs/heads/main/影视/网盘/虎斑.js
 
 // 引入 OmniBox SDK
@@ -1165,6 +1165,9 @@ async function detail(params, context) {
 
           const normalizedOriginalEpisodeName = normalizeEpisodeName(file.file_name || fileName);
           const playMeta = encodePlayMeta({
+            sid: videoId,
+            fid: fileId ? `${shareURL}|${fileId}` : "",
+            v: vodName || "",
             t: vodName,
             e: normalizedOriginalEpisodeName,
           });
@@ -1378,9 +1381,25 @@ async function play(params, context) {
       throw new Error("播放参数格式错误,应为:分享链接|文件ID");
     }
 
-    const shareURL = idParts[0] || "";
-    const fileId = idParts[1] || "";
-    const videoId = idParts[2] || "";
+    let playMeta = {};
+    let coreParts = [...idParts];
+    if (coreParts.length >= 3) {
+      const possibleMeta = coreParts[coreParts.length - 1] || "";
+      try {
+        playMeta = decodePlayMeta(possibleMeta);
+        if (playMeta && typeof playMeta === "object" && (playMeta.v || playMeta.e || playMeta.fid || playMeta.sid || playMeta.t)) {
+          coreParts = coreParts.slice(0, -1);
+        } else {
+          playMeta = {};
+        }
+      } catch (_) {
+        playMeta = {};
+      }
+    }
+
+    const shareURL = coreParts[0] || "";
+    const fileId = coreParts[1] || "";
+    const videoId = playMeta.sid || coreParts[2] || "";
 
     if (!shareURL || !fileId) {
       throw new Error("分享链接或文件ID不能为空");
@@ -1399,7 +1418,7 @@ async function play(params, context) {
         scrapeTitle: "",
         scrapePic: "",
         episodeNumber: null,
-        episodeName: params.episodeName || "",
+        episodeName: params.episodeName || playMeta.e || "",
       };
 
       if (!videoId) return result;

--- a/影视/网盘/蜡笔.js
+++ b/影视/网盘/蜡笔.js
@@ -2,7 +2,7 @@
 // @author 
 // @description 刮削：支持，弹幕：支持，播放记录：支持
 // @dependencies: axios, cheerio
-// @version 1.0.5
+// @version 1.0.6
 // @downloadURL https://gh-proxy.org/https://github.com/Silent1566/OmniBox-Spider/raw/refs/heads/main/影视/网盘/蜡笔.js
 
 // 引入 OmniBox SDK
@@ -1165,6 +1165,9 @@ async function detail(params, context) {
 
           const normalizedOriginalEpisodeName = normalizeEpisodeName(file.file_name || fileName);
           const playMeta = encodePlayMeta({
+            sid: videoId,
+            fid: fileId ? `${shareURL}|${fileId}` : "",
+            v: vodName || "",
             t: vodName,
             e: normalizedOriginalEpisodeName,
           });
@@ -1378,9 +1381,25 @@ async function play(params, context) {
       throw new Error("播放参数格式错误,应为:分享链接|文件ID");
     }
 
-    const shareURL = idParts[0] || "";
-    const fileId = idParts[1] || "";
-    const videoId = idParts[2] || "";
+    let playMeta = {};
+    let coreParts = [...idParts];
+    if (coreParts.length >= 3) {
+      const possibleMeta = coreParts[coreParts.length - 1] || "";
+      try {
+        playMeta = decodePlayMeta(possibleMeta);
+        if (playMeta && typeof playMeta === "object" && (playMeta.v || playMeta.e || playMeta.fid || playMeta.sid || playMeta.t)) {
+          coreParts = coreParts.slice(0, -1);
+        } else {
+          playMeta = {};
+        }
+      } catch (_) {
+        playMeta = {};
+      }
+    }
+
+    const shareURL = coreParts[0] || "";
+    const fileId = coreParts[1] || "";
+    const videoId = playMeta.sid || coreParts[2] || "";
 
     if (!shareURL || !fileId) {
       throw new Error("分享链接或文件ID不能为空");
@@ -1399,7 +1418,7 @@ async function play(params, context) {
         scrapeTitle: "",
         scrapePic: "",
         episodeNumber: null,
-        episodeName: params.episodeName || "",
+        episodeName: params.episodeName || playMeta.e || "",
       };
 
       if (!videoId) return result;

--- a/影视/网盘/闪电.js
+++ b/影视/网盘/闪电.js
@@ -2,7 +2,7 @@
 // @author
 // @description 刮削：支持，弹幕：支持，播放记录：支持
 // @dependencies: axios, cheerio
-// @version 1.0.5
+// @version 1.0.6
 // @downloadURL https://gh-proxy.org/https://github.com/Silent1566/OmniBox-Spider/raw/refs/heads/main/影视/网盘/闪电.js
 
 // 引入 OmniBox SDK
@@ -1165,6 +1165,9 @@ async function detail(params, context) {
 
           const normalizedOriginalEpisodeName = normalizeEpisodeName(file.file_name || fileName);
           const playMeta = encodePlayMeta({
+            sid: videoId,
+            fid: fileId ? `${shareURL}|${fileId}` : "",
+            v: vodName || "",
             t: vodName,
             e: normalizedOriginalEpisodeName,
           });
@@ -1378,9 +1381,25 @@ async function play(params, context) {
       throw new Error("播放参数格式错误,应为:分享链接|文件ID");
     }
 
-    const shareURL = idParts[0] || "";
-    const fileId = idParts[1] || "";
-    const videoId = idParts[2] || "";
+    let playMeta = {};
+    let coreParts = [...idParts];
+    if (coreParts.length >= 3) {
+      const possibleMeta = coreParts[coreParts.length - 1] || "";
+      try {
+        playMeta = decodePlayMeta(possibleMeta);
+        if (playMeta && typeof playMeta === "object" && (playMeta.v || playMeta.e || playMeta.fid || playMeta.sid || playMeta.t)) {
+          coreParts = coreParts.slice(0, -1);
+        } else {
+          playMeta = {};
+        }
+      } catch (_) {
+        playMeta = {};
+      }
+    }
+
+    const shareURL = coreParts[0] || "";
+    const fileId = coreParts[1] || "";
+    const videoId = playMeta.sid || coreParts[2] || "";
 
     if (!shareURL || !fileId) {
       throw new Error("分享链接或文件ID不能为空");
@@ -1399,7 +1418,7 @@ async function play(params, context) {
         scrapeTitle: "",
         scrapePic: "",
         episodeNumber: null,
-        episodeName: params.episodeName || "",
+        episodeName: params.episodeName || playMeta.e || "",
       };
 
       if (!videoId) return result;


### PR DESCRIPTION
## 变更内容
- 将 `木偶.js` 刚修好的“透传元数据 / play 解析”修复，同步到同类网盘源：
  - `影视/网盘/二小.js`
  - `影视/网盘/虎斑.js`
  - `影视/网盘/快映.js`
  - `影视/网盘/蜡笔.js`
  - `影视/网盘/欧哥.js`
  - `影视/网盘/闪电.js`
  - `影视/网盘/至臻.js`
- detail 阶段 `playMeta` 补全：
  - `sid`
  - `fid`
  - `v`
  - `t`
  - `e`
- play 阶段兼容三段 `playId`：
  - `shareURL|fileId|base64Meta`
- 优先使用 `playMeta.sid` 作为真正的 `videoId`
- 优先使用 `playMeta.e` 作为默认 `episodeName`

## 验证
- `node --check 影视/网盘/二小.js`
- `node --check 影视/网盘/虎斑.js`
- `node --check 影视/网盘/快映.js`
- `node --check 影视/网盘/蜡笔.js`
- `node --check 影视/网盘/欧哥.js`
- `node --check 影视/网盘/闪电.js`
- `node --check 影视/网盘/至臻.js`

## 说明
- 本次仅纳入以上 7 个网盘源文件
- 未带入仓库中其他未跟踪文件或无关改动
