### PR TITLE
fix: 调整 MakkaPakka 聚合导航目录并对齐搜索行为

### DIFF
--- a/导航/MakkaPakka聚合导航.js
+++ b/导航/MakkaPakka聚合导航.js
@@ -1,7 +1,8 @@
 // @name MakkaPakka聚合导航
 // @author 梦
 // @description 基于 AstrBot Widget 通用桥接的 OmniBox 导航源，动态读取远端 Widget Metadata 与模块函数
-// @version 1.0.0
+// @indexs 1
+// @version 1.0.3
 // @downloadURL https://gh-proxy.org/https://github.com/Silent1566/OmniBox-Spider/raw/refs/heads/main/综合/导航/MakkaPakka聚合导航.js
 
 const OmniBox = require("omnibox_sdk");
@@ -77,13 +78,17 @@ async function home(params, context) {
       filters[categoryId] = filterList;
     }
 
-    const list = [];
-    if (modules.length > 0) {
-      const firstCategoryId = modules[0].functionName;
-      const firstModule = modules[0];
-      const initialParams = buildModuleParams(firstModule, 1, {});
-      const items = await callWidgetModule(widget, firstCategoryId, initialParams);
-      list.push(...mapWidgetItemsToOmniBox(items, firstCategoryId, firstModule, context));
+    let list = [];
+    for (const mod of modules) {
+      const categoryId = mod.functionName;
+      const initialParams = buildModuleParams(mod, 1, {});
+      const items = await callWidgetModule(widget, categoryId, initialParams);
+      const mapped = mapWidgetItemsToOmniBox(items, categoryId, mod, context);
+      await safeLog("info", `Makka导航 home 模块尝试: ${categoryId} raw=${Array.isArray(items) ? items.length : 0} mapped=${mapped.length}`);
+      if (mapped.length > 0) {
+        list = mapped;
+        break;
+      }
     }
 
     return {
@@ -127,7 +132,7 @@ async function category(params, context) {
           buildTextVod({
             title: "未找到对应栏目",
             description: `categoryId=${categoryId}`,
-            typeName: "提示",
+            typeName: "提示"
           }),
         ],
       };
@@ -416,6 +421,7 @@ function mapSingleItem(item, index, typeName, context) {
   }
 
   return {
+    // 豆瓣推荐的兼容做法：保留原始 id / tmdbId，只通过 search: true 提示宿主走搜索。
     vod_id: String(item.tmdbId || item.id || `${typeName}_${index + 1}`),
     vod_name: title,
     vod_pic: posterPath,
@@ -488,5 +494,5 @@ function simpleHash(input) {
 async function safeLog(level, message) {
   try {
     await OmniBox.log(level, message);
-  } catch (_) {}
+  } catch (_) { }
 }

--- a/影视/网盘/影巢.js
+++ b/影视/网盘/影巢.js
@@ -2,7 +2,7 @@
 // @author lampon
 // @description
 // @dependencies axios
-// @version 1.1.5
+// @version 1.1.7
 // @downloadURL https://gh-proxy.org/https://github.com/Silent1566/OmniBox-Spider/raw/refs/heads/main/影视/网盘/影巢.js
 
 const OmniBox = require("omnibox_sdk");
@@ -47,6 +47,10 @@ const HDHIVE_PROXY_URL = process.env.HDHIVE_PROXY_URL || "";
 const PANCHECK_API = process.env.PANCHECK_API || "";
 const PANCHECK_ENABLED = true;
 const PANCHECK_PLATFORMS = process.env.PANCHECK_PLATFORMS || "quark";
+// HDHive /resources/unlock 限流配置：1 分钟窗口内最多 3 次，超限后直接短路返回。
+const HDHIVE_RATE_LIMIT_WINDOW_MS = 60 * 1000;
+const HDHIVE_RATE_LIMIT_MAX_CALLS = 3;
+const HDHIVE_RATE_LIMIT_CACHE_KEY = "yingchao:hdhive:unlock-rate-limit";
 // 读取环境变量：支持多个网盘类型，用分号分割；仅这些网盘类型启用多线路
 const DRIVE_TYPE_CONFIG = (process.env.DRIVE_TYPE_CONFIG || "quark;uc")
   .split(";")
@@ -658,10 +662,49 @@ async function checkLinksWithPanCheck(links) {
   }
 }
 
+async function getHDHiveRateLimitState() {
+  try {
+    const raw = await OmniBox.getCache(HDHIVE_RATE_LIMIT_CACHE_KEY);
+    if (!raw) return { startedAt: Date.now(), count: 0 };
+    const parsed = typeof raw === "string" ? JSON.parse(raw) : raw;
+    const startedAt = Number(parsed?.startedAt || 0);
+    const count = Number(parsed?.count || 0);
+    if (!startedAt || Date.now() - startedAt >= HDHIVE_RATE_LIMIT_WINDOW_MS) {
+      return { startedAt: Date.now(), count: 0 };
+    }
+    return { startedAt, count };
+  } catch (_) {
+    return { startedAt: Date.now(), count: 0 };
+  }
+}
+
+async function markHDHiveRateLimitHit() {
+  const state = await getHDHiveRateLimitState();
+  const next = { startedAt: state.startedAt, count: state.count + 1 };
+  const ttlSeconds = Math.max(1, Math.ceil((HDHIVE_RATE_LIMIT_WINDOW_MS - (Date.now() - next.startedAt)) / 1000));
+  try {
+    await OmniBox.setCache(HDHIVE_RATE_LIMIT_CACHE_KEY, JSON.stringify(next), ttlSeconds);
+  } catch (_) {
+    // ignore
+  }
+  return next;
+}
+
 async function requestHDHive(path, method = "GET", bodyObj = null) {
   if (!HDHIVE_API_KEY) {
     throw new Error("HDHive API Key 未配置：请设置 HDHIVE_API_KEY");
   }
+
+  if (path === "/resources/unlock") {
+    const rateState = await getHDHiveRateLimitState();
+    if (rateState.count >= HDHIVE_RATE_LIMIT_MAX_CALLS) {
+      const message = `HDHive unlock 限流触发: 1分钟内超过${HDHIVE_RATE_LIMIT_MAX_CALLS}次，跳过请求 ${method} ${path}`;
+      await OmniBox.log("warn", message);
+      return { success: false, data: null, message, code: "429", rateLimited: true };
+    }
+    await markHDHiveRateLimitHit();
+  }
+
   const url = `${HDHIVE_API_BASE_URL}${path}`;
   const headers = {
     Accept: "*/*",
@@ -1631,6 +1674,10 @@ async function detail(params, context) {
     const unlockResp = await requestHDHive("/resources/unlock", "POST", {
       slug: payload.slug,
     });
+    if (unlockResp?.rateLimited) {
+      await OmniBox.log("warn", `tmdb.js detail 被限流短路: slug=${payload.slug}`);
+      return { list: [] };
+    }
     const shareURL = safeString(
       unlockResp?.data?.full_url || unlockResp?.data?.url,
     );


### PR DESCRIPTION
## 变更内容
- 将 `MakkaPakka聚合导航.js` 迁移到 `导航/` 目录，与 `豆瓣推荐.js` 同级
- 调整该导航源条目行为，按 `豆瓣推荐.js` 的兼容方式：
  - 保留原始 `vod_id`
  - 保留 `search: true`
  - 保留 `link`
- 首页策略改为按模块顺序依次尝试，命中第一个有数据的模块即作为首页列表
- 修正 `@downloadURL` 到新路径：
  - `导航/MakkaPakka聚合导航.js`

## 验证
- `node --check 导航/MakkaPakka聚合导航.js`

## 说明
- 本次仅纳入 `导航/MakkaPakka聚合导航.js`（及其原路径移动）
- 未带入仓库中其他未跟踪文件或无关改动
