### PR TITLE
feat: 新增毒舌影视采集源

### DIFF
--- a/影视/网盘/人人电影.py
+++ b/影视/网盘/人人电影.py
@@ -2,10 +2,8 @@
 # @name 人人电影
 # @author 梦
 # @description 影视站：https://www.rrdynb.com/ ，支持首页、分类、搜索、详情与网盘线路提取（Python版）
-# @version 1.1.4
+# @version 1.1.2
 # @downloadURL https://gh-proxy.org/https://github.com/Silent1566/OmniBox-Spider/raw/refs/heads/main/影视/网盘/人人电影.py
-# @dependencies curl_cffi,cloudscraper
-# @dependencies curl_cffi,cloudscraper
 
 import json
 import html
@@ -14,21 +12,8 @@ import re
 from urllib.parse import quote
 from spider_runner import OmniBox, run
 
-try:
-    from curl_cffi import requests as curl_requests
-except Exception:
-    curl_requests = None
-
-try:
-    import cloudscraper
-except Exception:
-    cloudscraper = None
-
 BASE_URL = "https://www.rrdynb.com"
 UA = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/135.0.0.0 Safari/537.36"
-RRDYNB_COOKIE = str(os.environ.get("RRDYNB_COOKIE") or "").strip()
-SEARCH_COOKIE_CACHE_KEY = "rrdynb:search-cookie"
-SEARCH_COOKIE_TTL_SECONDS = int(os.environ.get("RRDYNB_SEARCH_COOKIE_TTL_SECONDS", "1800") or 1800)
 
 CATEGORY_MAP = {
     "movie": {"type_id": "2", "type_name": "电影", "path": "/movie/"},
@@ -124,120 +109,20 @@ async def log(level: str, message: str):
         pass
 
 
-def is_cf_challenge(text: str) -> bool:
-    raw = str(text or "")
-    return "Just a moment" in raw or "Enable JavaScript and cookies to continue" in raw or "cf-mitigated" in raw
-
-
-def cookiejar_to_string(jar) -> str:
-    try:
-        if jar is None:
-            return ""
-        if hasattr(jar, "items"):
-            return "; ".join(f"{k}={v}" for k, v in jar.items())
-        if hasattr(jar, "get_dict"):
-            data = jar.get_dict()
-            return "; ".join(f"{k}={v}" for k, v in data.items())
-    except Exception:
-        return ""
-    return ""
-
-
-async def load_search_cookie() -> str:
-    if RRDYNB_COOKIE:
-        return RRDYNB_COOKIE
-    try:
-        value = await OmniBox.getCache(SEARCH_COOKIE_CACHE_KEY)
-        return str(value or "").strip()
-    except Exception:
-        return ""
-
-
-async def save_search_cookie(cookie: str):
-    cookie = str(cookie or "").strip()
-    if not cookie:
-        return
-    try:
-        await OmniBox.setCache(SEARCH_COOKIE_CACHE_KEY, cookie, SEARCH_COOKIE_TTL_SECONDS)
-    except Exception:
-        pass
-
-
-async def clear_search_cookie():
-    try:
-        await OmniBox.deleteCache(SEARCH_COOKIE_CACHE_KEY)
-    except Exception:
-        try:
-            await OmniBox.setCache(SEARCH_COOKIE_CACHE_KEY, "", 1)
-        except Exception:
-            pass
-
-
-async def request_text(url: str, referer: str = None, cookie: str = "") -> str:
-    headers = {
-        "User-Agent": UA,
-        "Referer": referer or f"{BASE_URL}/",
-        "Accept-Language": "zh-CN,zh;q=0.9,en;q=0.8",
-        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
-    }
-    cookie = str(cookie or "").strip()
-    if cookie:
-        headers["Cookie"] = cookie
-
-    async def save_from_jar(jar, fallback_cookie=""):
-        merged = cookiejar_to_string(jar) or fallback_cookie
-        if merged:
-            await save_search_cookie(merged)
-        return merged
-
-    if curl_requests is not None:
-        try:
-            session = curl_requests.Session(impersonate="chrome124")
-            # 先预热首页，同会话拿 cookie，再打搜索
-            session.get(BASE_URL, headers={**headers, "Referer": f"{BASE_URL}/"}, timeout=20)
-            resp = session.get(url, headers=headers, timeout=20)
-            text = str(resp.text or "")
-            status = int(resp.status_code or 0)
-            if (status != 200 or is_cf_challenge(text)):
-                await save_from_jar(getattr(session, "cookies", None), cookie)
-                resp = session.get(url, headers=headers, timeout=20)
-                text = str(resp.text or "")
-                status = int(resp.status_code or 0)
-            if status == 200 and not is_cf_challenge(text):
-                await save_from_jar(getattr(session, "cookies", None), cookie)
-                return text
-        except Exception:
-            pass
-
-    if cloudscraper is not None:
-        try:
-            scraper = cloudscraper.create_scraper(browser={"browser": "chrome", "platform": "windows", "mobile": False})
-            scraper.get(BASE_URL, headers={**headers, "Referer": f"{BASE_URL}/"}, timeout=20)
-            resp = scraper.get(url, headers=headers, timeout=20)
-            text = str(resp.text or "")
-            status = int(resp.status_code or 0)
-            if (status != 200 or is_cf_challenge(text)):
-                await save_from_jar(getattr(scraper, "cookies", None), cookie)
-                resp = scraper.get(url, headers=headers, timeout=20)
-                text = str(resp.text or "")
-                status = int(resp.status_code or 0)
-            if status == 200 and not is_cf_challenge(text):
-                await save_from_jar(getattr(scraper, "cookies", None), cookie)
-                return text
-        except Exception:
-            pass
-
+async def request_text(url: str, referer: str = None) -> str:
     res = await OmniBox.request(url, {
         "method": "GET",
-        "headers": headers,
+        "headers": {
+            "User-Agent": UA,
+            "Referer": referer or f"{BASE_URL}/",
+            "Accept-Language": "zh-CN,zh;q=0.9,en;q=0.8",
+        },
     })
     status = int(res.get("statusCode") or 0)
     body = res.get("body", "")
     text = body.decode("utf-8", "ignore") if isinstance(body, (bytes, bytearray)) else str(body or "")
-    if status != 200 or is_cf_challenge(text):
+    if status != 200:
         raise RuntimeError(f"HTTP {status} @ {url}")
-    if cookie:
-        await save_search_cookie(cookie)
     return text
 
 
@@ -768,20 +653,7 @@ async def search(params, context):
         if page > 1:
             return {"page": page, "pagecount": 1, "total": 0, "list": []}
         url = f"{BASE_URL}/plus/search.php?q={quote(keyword)}&pagesize=10"
-
-        text = ""
-        cached_cookie = await load_search_cookie()
-        if cached_cookie:
-            await log("info", f"[rrdynb][search] try cached cookie")
-            try:
-                text = await request_text(url, referer=f"{BASE_URL}/", cookie=cached_cookie)
-            except Exception as e:
-                await log("warn", f"[rrdynb][search] cached cookie failed: {e}")
-                await clear_search_cookie()
-
-        if not text:
-            text = await request_text(url, referer=f"{BASE_URL}/")
-
+        text = await request_text(url, referer=f"{BASE_URL}/")
         merged = []
         for cfg in CATEGORY_MAP.values():
             merged.extend(extract_cards(text, cfg["type_id"], cfg["type_name"]))

--- a/影视/网盘/人人电影.py
+++ b/影视/网盘/人人电影.py
@@ -2,8 +2,10 @@
 # @name 人人电影
 # @author 梦
 # @description 影视站：https://www.rrdynb.com/ ，支持首页、分类、搜索、详情与网盘线路提取（Python版）
-# @version 1.1.2
+# @version 1.1.4
 # @downloadURL https://gh-proxy.org/https://github.com/Silent1566/OmniBox-Spider/raw/refs/heads/main/影视/网盘/人人电影.py
+# @dependencies curl_cffi,cloudscraper
+# @dependencies curl_cffi,cloudscraper
 
 import json
 import html
@@ -12,8 +14,21 @@ import re
 from urllib.parse import quote
 from spider_runner import OmniBox, run
 
+try:
+    from curl_cffi import requests as curl_requests
+except Exception:
+    curl_requests = None
+
+try:
+    import cloudscraper
+except Exception:
+    cloudscraper = None
+
 BASE_URL = "https://www.rrdynb.com"
 UA = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/135.0.0.0 Safari/537.36"
+RRDYNB_COOKIE = str(os.environ.get("RRDYNB_COOKIE") or "").strip()
+SEARCH_COOKIE_CACHE_KEY = "rrdynb:search-cookie"
+SEARCH_COOKIE_TTL_SECONDS = int(os.environ.get("RRDYNB_SEARCH_COOKIE_TTL_SECONDS", "1800") or 1800)
 
 CATEGORY_MAP = {
     "movie": {"type_id": "2", "type_name": "电影", "path": "/movie/"},
@@ -109,20 +124,120 @@ async def log(level: str, message: str):
         pass
 
 
-async def request_text(url: str, referer: str = None) -> str:
+def is_cf_challenge(text: str) -> bool:
+    raw = str(text or "")
+    return "Just a moment" in raw or "Enable JavaScript and cookies to continue" in raw or "cf-mitigated" in raw
+
+
+def cookiejar_to_string(jar) -> str:
+    try:
+        if jar is None:
+            return ""
+        if hasattr(jar, "items"):
+            return "; ".join(f"{k}={v}" for k, v in jar.items())
+        if hasattr(jar, "get_dict"):
+            data = jar.get_dict()
+            return "; ".join(f"{k}={v}" for k, v in data.items())
+    except Exception:
+        return ""
+    return ""
+
+
+async def load_search_cookie() -> str:
+    if RRDYNB_COOKIE:
+        return RRDYNB_COOKIE
+    try:
+        value = await OmniBox.getCache(SEARCH_COOKIE_CACHE_KEY)
+        return str(value or "").strip()
+    except Exception:
+        return ""
+
+
+async def save_search_cookie(cookie: str):
+    cookie = str(cookie or "").strip()
+    if not cookie:
+        return
+    try:
+        await OmniBox.setCache(SEARCH_COOKIE_CACHE_KEY, cookie, SEARCH_COOKIE_TTL_SECONDS)
+    except Exception:
+        pass
+
+
+async def clear_search_cookie():
+    try:
+        await OmniBox.deleteCache(SEARCH_COOKIE_CACHE_KEY)
+    except Exception:
+        try:
+            await OmniBox.setCache(SEARCH_COOKIE_CACHE_KEY, "", 1)
+        except Exception:
+            pass
+
+
+async def request_text(url: str, referer: str = None, cookie: str = "") -> str:
+    headers = {
+        "User-Agent": UA,
+        "Referer": referer or f"{BASE_URL}/",
+        "Accept-Language": "zh-CN,zh;q=0.9,en;q=0.8",
+        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+    }
+    cookie = str(cookie or "").strip()
+    if cookie:
+        headers["Cookie"] = cookie
+
+    async def save_from_jar(jar, fallback_cookie=""):
+        merged = cookiejar_to_string(jar) or fallback_cookie
+        if merged:
+            await save_search_cookie(merged)
+        return merged
+
+    if curl_requests is not None:
+        try:
+            session = curl_requests.Session(impersonate="chrome124")
+            # 先预热首页，同会话拿 cookie，再打搜索
+            session.get(BASE_URL, headers={**headers, "Referer": f"{BASE_URL}/"}, timeout=20)
+            resp = session.get(url, headers=headers, timeout=20)
+            text = str(resp.text or "")
+            status = int(resp.status_code or 0)
+            if (status != 200 or is_cf_challenge(text)):
+                await save_from_jar(getattr(session, "cookies", None), cookie)
+                resp = session.get(url, headers=headers, timeout=20)
+                text = str(resp.text or "")
+                status = int(resp.status_code or 0)
+            if status == 200 and not is_cf_challenge(text):
+                await save_from_jar(getattr(session, "cookies", None), cookie)
+                return text
+        except Exception:
+            pass
+
+    if cloudscraper is not None:
+        try:
+            scraper = cloudscraper.create_scraper(browser={"browser": "chrome", "platform": "windows", "mobile": False})
+            scraper.get(BASE_URL, headers={**headers, "Referer": f"{BASE_URL}/"}, timeout=20)
+            resp = scraper.get(url, headers=headers, timeout=20)
+            text = str(resp.text or "")
+            status = int(resp.status_code or 0)
+            if (status != 200 or is_cf_challenge(text)):
+                await save_from_jar(getattr(scraper, "cookies", None), cookie)
+                resp = scraper.get(url, headers=headers, timeout=20)
+                text = str(resp.text or "")
+                status = int(resp.status_code or 0)
+            if status == 200 and not is_cf_challenge(text):
+                await save_from_jar(getattr(scraper, "cookies", None), cookie)
+                return text
+        except Exception:
+            pass
+
     res = await OmniBox.request(url, {
         "method": "GET",
-        "headers": {
-            "User-Agent": UA,
-            "Referer": referer or f"{BASE_URL}/",
-            "Accept-Language": "zh-CN,zh;q=0.9,en;q=0.8",
-        },
+        "headers": headers,
     })
     status = int(res.get("statusCode") or 0)
     body = res.get("body", "")
     text = body.decode("utf-8", "ignore") if isinstance(body, (bytes, bytearray)) else str(body or "")
-    if status != 200:
+    if status != 200 or is_cf_challenge(text):
         raise RuntimeError(f"HTTP {status} @ {url}")
+    if cookie:
+        await save_search_cookie(cookie)
     return text
 
 
@@ -653,7 +768,20 @@ async def search(params, context):
         if page > 1:
             return {"page": page, "pagecount": 1, "total": 0, "list": []}
         url = f"{BASE_URL}/plus/search.php?q={quote(keyword)}&pagesize=10"
-        text = await request_text(url, referer=f"{BASE_URL}/")
+
+        text = ""
+        cached_cookie = await load_search_cookie()
+        if cached_cookie:
+            await log("info", f"[rrdynb][search] try cached cookie")
+            try:
+                text = await request_text(url, referer=f"{BASE_URL}/", cookie=cached_cookie)
+            except Exception as e:
+                await log("warn", f"[rrdynb][search] cached cookie failed: {e}")
+                await clear_search_cookie()
+
+        if not text:
+            text = await request_text(url, referer=f"{BASE_URL}/")
+
         merged = []
         for cfg in CATEGORY_MAP.values():
             merged.extend(extract_cards(text, cfg["type_id"], cfg["type_name"]))

--- a/影视/采集/毒舌影视.js
+++ b/影视/采集/毒舌影视.js
@@ -1,0 +1,490 @@
+// @name 毒舌影视
+// @author 梦
+// @description 影视站：https://www.xnhrsb.com/ ，支持首页、分类、详情、搜索与播放
+// @dependencies cheerio
+// @version 1.0.3
+// @downloadURL https://gh-proxy.org/https://github.com/Silent1566/OmniBox-Spider/raw/refs/heads/main/影视/采集/毒舌影视.js
+
+const OmniBox = require("omnibox_sdk");
+const runner = require("spider_runner");
+const cheerio = require("cheerio");
+
+const BASE_URL = (process.env.DUSHE_HOST || "https://m.xnhrsb.com").replace(/\/$/, "");
+const UA = process.env.DUSHE_UA || "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1";
+const HOME_CACHE_TTL = Number(process.env.DUSHE_HOME_CACHE_TTL || 900);
+const CATEGORY_CACHE_TTL = Number(process.env.DUSHE_CATEGORY_CACHE_TTL || 900);
+const DETAIL_CACHE_TTL = Number(process.env.DUSHE_DETAIL_CACHE_TTL || 1800);
+const SEARCH_CACHE_TTL = Number(process.env.DUSHE_SEARCH_CACHE_TTL || 600);
+const PLAY_CACHE_TTL = Number(process.env.DUSHE_PLAY_CACHE_TTL || 900);
+
+const CATEGORY_CONFIG = [
+  { id: "1", name: "电影" },
+  { id: "2", name: "电视剧" },
+  { id: "3", name: "综艺" },
+  { id: "4", name: "动漫" },
+  { id: "5", name: "短剧" },
+  { id: "duoban", name: "豆瓣" },
+];
+
+const CLASS_LIST = CATEGORY_CONFIG.map((item) => ({ type_id: item.id, type_name: item.name }));
+const FILTERS = Object.fromEntries(
+  CATEGORY_CONFIG.map((item) => [
+    item.id,
+    [
+      {
+        key: "type",
+        name: "分类",
+        value: [{ name: "全部", value: item.id }],
+      },
+    ],
+  ])
+);
+
+module.exports = { home, category, detail, search, play };
+runner.run(module.exports);
+
+function absUrl(url) {
+  const raw = String(url || "").trim();
+  if (!raw) return "";
+  if (/^https?:\/\//i.test(raw)) return raw;
+  if (raw.startsWith("//")) return `https:${raw}`;
+  try {
+    return new URL(raw, `${BASE_URL}/`).toString();
+  } catch (_) {
+    return raw;
+  }
+}
+
+function cleanText(value) {
+  return String(value || "")
+    .replace(/&nbsp;/gi, " ")
+    .replace(/&#160;/gi, " ")
+    .replace(/<br\s*\/?>/gi, "\n")
+    .replace(/<[^>]+>/g, " ")
+    .replace(/\r/g, "")
+    .replace(/[ \t\f\v]+/g, " ")
+    .replace(/\n\s*\n+/g, "\n")
+    .trim();
+}
+
+function dedupeVodList(list) {
+  const out = [];
+  const seen = new Set();
+  for (const item of Array.isArray(list) ? list : []) {
+    const key = String(item?.vod_id || item?.vod_name || "");
+    if (!key || seen.has(key)) continue;
+    seen.add(key);
+    out.push(item);
+  }
+  return out;
+}
+
+async function requestText(url, options = {}) {
+  const method = options.method || "GET";
+  await OmniBox.log("info", `[毒舌影视][request] ${method} ${url}`);
+  const res = await OmniBox.request(url, {
+    method,
+    headers: {
+      "User-Agent": UA,
+      "Accept-Language": "zh-CN,zh;q=0.9,en;q=0.8",
+      Referer: options.referer || `${BASE_URL}/`,
+      ...(options.headers || {}),
+    },
+    body: options.body,
+    timeout: options.timeout || 20000,
+  });
+  const statusCode = Number(res?.statusCode || 0);
+  const body = res?.body;
+  const text = typeof body === "string" ? body : String(body || "");
+  if (statusCode !== 200) {
+    throw new Error(`HTTP ${statusCode || "unknown"} @ ${url}`);
+  }
+  return text;
+}
+
+async function getCachedText(cacheKey, ttl, producer) {
+  try {
+    const cached = await OmniBox.getCache(cacheKey);
+    if (cached) return String(cached);
+  } catch (_) {}
+  const text = String(await producer());
+  try {
+    await OmniBox.setCache(cacheKey, text, ttl);
+  } catch (_) {}
+  return text;
+}
+
+function buildCard($, li) {
+  const node = $(li);
+  const anchor = node.find("a[href]").first();
+  const titleAnchor = node.find(".dytit a[href]").first();
+  const href = titleAnchor.attr("href") || anchor.attr("href") || "";
+  const img = node.find("img").first();
+  const title = cleanText(titleAnchor.text() || img.attr("alt") || anchor.attr("title") || "");
+  const pic = img.attr("data-original") || img.attr("src") || "";
+  const remarks = cleanText(node.find(".hdinfo,.jidi,.bz").first().text());
+  const actor = cleanText(node.find(".inzhuy").first().text().replace(/^主演[:：]?/, ""));
+  return {
+    vod_id: absUrl(href),
+    vod_name: title,
+    vod_pic: absUrl(pic),
+    vod_remarks: remarks,
+    vod_actor: actor,
+  };
+}
+
+function parseHomeList(html) {
+  const $ = cheerio.load(html);
+  const list = [];
+  $(".bt_img ul li").each((_, li) => list.push(buildCard($, li)));
+  return dedupeVodList(list).filter((item) => item.vod_id && item.vod_name);
+}
+
+function parseCategoryList(html) {
+  const $ = cheerio.load(html);
+  const list = [];
+  $(".bt_img ul li").each((_, li) => list.push(buildCard($, li)));
+
+  let pagecount = 1;
+  $("a[href]").each((_, a) => {
+    const href = $(a).attr("href") || "";
+    const matches = [...href.matchAll(/-(\d+)---\.html/g)];
+    for (const m of matches) {
+      const n = Number(m[1] || 1);
+      if (Number.isFinite(n)) pagecount = Math.max(pagecount, n);
+    }
+  });
+
+  return {
+    list: dedupeVodList(list).filter((item) => item.vod_id && item.vod_name),
+    pagecount,
+  };
+}
+
+function parseMetaByLabel($, labels) {
+  const needle = Array.isArray(labels) ? labels : [labels];
+  let found = "";
+  $("li,p,span,div").each((_, el) => {
+    if (found) return;
+    const text = cleanText($(el).text());
+    if (!text) return;
+    for (const label of needle) {
+      const normalized = String(label || "");
+      if (text.startsWith(normalized)) {
+        found = text.replace(new RegExp(`^${normalized}`), "").trim();
+        return;
+      }
+    }
+  });
+  return found;
+}
+
+function parseDetailSources($, detailUrl) {
+  const sources = [];
+
+  $(".mi_paly_box, .play_source, .playlist, .stui-content__playlist").each((_, box) => {
+    const node = $(box);
+    const sourceName = cleanText(
+      node.find(".ypxingq_t,.option,.nav-tabs li.active,a.active,li.active,span.active,h3,h4").first().text()
+    ) || `线路${sources.length + 1}`;
+    const episodes = [];
+    node.find(".paly_list_btn a[href], .playlist a[href], li a[href], a[href]").each((__, a) => {
+      const href = $(a).attr("href") || "";
+      const name = cleanText($(a).attr("title") || $(a).text());
+      if (!href || !name) return;
+      episodes.push({ name, playId: absUrl(href) });
+    });
+    if (episodes.length) sources.push({ name: sourceName, episodes });
+  });
+
+  if (!sources.length) {
+    const episodes = [];
+    $("a[href]").each((_, a) => {
+      const href = $(a).attr("href") || "";
+      const name = cleanText($(a).attr("title") || $(a).text());
+      if (!/\/dsshiyipy\//.test(href)) return;
+      if (!name) return;
+      episodes.push({ name, playId: absUrl(href) });
+    });
+    if (episodes.length) {
+      sources.push({ name: "在线播放", episodes: dedupeEpisodes(episodes) });
+    }
+  }
+
+  if (!sources.length && detailUrl) {
+    sources.push({
+      name: "在线播放",
+      episodes: [{ name: "立即播放", playId: String(detailUrl) }],
+    });
+  }
+
+  return sources.map((source) => ({ ...source, episodes: dedupeEpisodes(source.episodes) }));
+}
+
+function shouldKeepEpisodeName(name) {
+  const text = cleanText(name || "");
+  if (!text) return false;
+  if (text.includes("APP秒播")) return false;
+  return true;
+}
+
+function dedupeEpisodes(episodes) {
+  const out = [];
+  const seen = new Set();
+  for (const ep of Array.isArray(episodes) ? episodes : []) {
+    const name = cleanText(ep?.name || "");
+    const playId = String(ep?.playId || "").trim();
+    const key = `${name}|${playId}`;
+    if (!name || !playId || !shouldKeepEpisodeName(name) || seen.has(key)) continue;
+    seen.add(key);
+    out.push({ ...ep, name, playId });
+  }
+  return out;
+}
+
+function parseDetail(html, detailUrl) {
+  const $ = cheerio.load(html);
+  const title = cleanText($("h1").first().text() || $("title").text().replace(/[-_].*$/, ""));
+  const pic = absUrl($("div.dyimg img, .dyimg img, .thumb img, .poster img, img.thumb").first().attr("src") || $("img[data-original]").first().attr("data-original") || "");
+  const remarks = parseMetaByLabel($, ["状态：", "备注：", "更新："]);
+  const year = parseMetaByLabel($, ["年份：", "年代："]);
+  const area = parseMetaByLabel($, ["地区："]);
+  const typeName = parseMetaByLabel($, ["类型："]);
+  const actor = parseMetaByLabel($, ["主演："]);
+  const director = parseMetaByLabel($, ["导演："]);
+  const lang = parseMetaByLabel($, ["语言："]);
+  const douban = parseMetaByLabel($, ["豆瓣：", "评分："]);
+  const content = cleanText($(".yp_context,.moviedteail_content,.content,.jianjie,.vod_content").first().html() || $("meta[name='description']").attr("content") || "");
+  const vod_play_sources = parseDetailSources($, detailUrl);
+
+  return {
+    vod_id: String(detailUrl || ""),
+    vod_name: title,
+    vod_pic: pic,
+    vod_remarks: remarks,
+    vod_year: year,
+    vod_area: area,
+    type_name: typeName,
+    vod_actor: actor,
+    vod_director: director,
+    vod_lang: lang,
+    vod_douban_score: douban,
+    vod_content: content,
+    vod_play_sources,
+  };
+}
+
+function resolvePlayUrl(rawUrl) {
+  let playUrl = String(rawUrl || "").trim();
+  if (!playUrl) return "";
+  playUrl = playUrl.replace(/\\\//g, "/").replace(/\\/g, "");
+  if (/^https?:\/\//i.test(playUrl)) return playUrl;
+  if (playUrl.startsWith("//")) return `https:${playUrl}`;
+  return absUrl(playUrl);
+}
+
+function extractJsonUrl(text) {
+  const raw = String(text || "");
+  const patterns = [
+    /player_aaaa\s*=\s*([^;]+);/i,
+    /MacPlayerConfig\.player_aaaa\s*=\s*([^;]+);/i,
+  ];
+  for (const pattern of patterns) {
+    const match = raw.match(pattern);
+    if (!match) continue;
+    try {
+      const data = JSON.parse(String(match[1]).replace(/'/g, '"'));
+      const url = data?.url || data?.src || "";
+      if (url) return url;
+    } catch (_) {}
+  }
+
+  const directPatterns = [
+    /["']url["']\s*[,:=]\s*["']([^"']+\.(?:m3u8|mp4)(?:[^"']*)?)["']/i,
+    /["']src["']\s*[,:=]\s*["']([^"']+\.(?:m3u8|mp4)(?:[^"']*)?)["']/i,
+    /sourceUrl\s*[=:]\s*["']?([^"'\s]+)["']?/i,
+    /video\.src\s*=\s*["']?([^"'\s]+)["']?/i,
+    /playUrl\s*[=:]\s*["']?([^"'\s]+)["']?/i,
+  ];
+  for (const pattern of directPatterns) {
+    const match = raw.match(pattern);
+    if (match?.[1]) return match[1];
+  }
+  return "";
+}
+
+async function resolvePlayPage(playPageUrl, referer) {
+  const html = await requestText(playPageUrl, { referer });
+  let playUrl = extractJsonUrl(html);
+  if (playUrl) return resolvePlayUrl(playUrl);
+
+  const apiMatch = html.match(/\$\.getJSON\(['"]([^'"]+)['"]/i);
+  if (apiMatch?.[1]) {
+    try {
+      const apiUrl = absUrl(apiMatch[1]);
+      const body = await requestText(apiUrl, { referer: playPageUrl });
+      try {
+        const json = JSON.parse(body);
+        const nested = json?.url || json?.data?.url || json?.data?.src || "";
+        if (nested) return resolvePlayUrl(nested);
+      } catch (_) {}
+    } catch (_) {}
+  }
+
+  const $ = cheerio.load(html);
+  const iframeSrc = $("iframe").first().attr("src") || "";
+  if (iframeSrc) {
+    const iframeUrl = absUrl(iframeSrc);
+    try {
+      const iframeHtml = await requestText(iframeUrl, { referer: playPageUrl });
+      playUrl = extractJsonUrl(iframeHtml);
+      if (playUrl) return resolvePlayUrl(playUrl);
+    } catch (_) {}
+  }
+
+  return "";
+}
+
+async function home() {
+  try {
+    const html = await getCachedText("dushe:home", HOME_CACHE_TTL, () => requestText(`${BASE_URL}/`));
+    const list = parseHomeList(html).slice(0, 24);
+    await OmniBox.log("info", `[毒舌影视][home] count=${list.length}`);
+    return {
+      class: CLASS_LIST,
+      filters: FILTERS,
+      list,
+    };
+  } catch (e) {
+    await OmniBox.log("error", `[毒舌影视][home] failed: ${e.message || e}`);
+    return {
+      class: CLASS_LIST,
+      filters: FILTERS,
+      list: [],
+    };
+  }
+}
+
+async function category(params = {}) {
+  try {
+    const tid = String(params.type_id || params.categoryId || params.tid || "1");
+    const page = Math.max(1, Number(params.page || params.pg || 1));
+    const url = `${BASE_URL}/dsshiyisw/${encodeURIComponent(tid)}--------${page}---.html`;
+    const html = await getCachedText(`dushe:category:${tid}:${page}`, CATEGORY_CACHE_TTL, () => requestText(url));
+    const parsed = parseCategoryList(html);
+    await OmniBox.log("info", `[毒舌影视][category] tid=${tid} page=${page} count=${parsed.list.length} pagecount=${parsed.pagecount}`);
+    return {
+      page,
+      pagecount: parsed.pagecount || page,
+      limit: parsed.list.length,
+      total: parsed.list.length,
+      filters: FILTERS[tid] || {},
+      list: parsed.list,
+    };
+  } catch (e) {
+    await OmniBox.log("error", `[毒舌影视][category] failed: ${e.message || e}`);
+    return {
+      page: Number(params.page || params.pg || 1) || 1,
+      pagecount: 1,
+      limit: 0,
+      total: 0,
+      filters: FILTERS[String(params.type_id || params.categoryId || params.tid || "1")] || {},
+      list: [],
+    };
+  }
+}
+
+async function detail(params = {}) {
+  try {
+    const vodId = absUrl(params.vod_id || params.videoId || params.id || "");
+    if (!vodId) {
+      await OmniBox.log("warn", `[毒舌影视][detail] empty id params=${JSON.stringify(params || {})}`);
+      return { list: [] };
+    }
+    const html = await getCachedText(`dushe:detail:${vodId}`, DETAIL_CACHE_TTL, () => requestText(vodId));
+    const vod = parseDetail(html, vodId);
+    await OmniBox.log("info", `[毒舌影视][detail] vod=${vod.vod_name || vodId} sources=${vod.vod_play_sources?.length || 0}`);
+    return { list: [vod] };
+  } catch (e) {
+    await OmniBox.log("error", `[毒舌影视][detail] failed: ${e.message || e}`);
+    return { list: [] };
+  }
+}
+
+async function search(params = {}) {
+  try {
+    const wd = String(params.wd || params.keyword || "").trim();
+    const page = Math.max(1, Number(params.page || 1));
+    if (!wd) {
+      return { page, pagecount: 1, limit: 0, total: 0, list: [] };
+    }
+    const url = `${BASE_URL}/dsshiyisc/${encodeURIComponent(wd)}----------${page}---.html`;
+    const html = await getCachedText(`dushe:search:${wd}:${page}`, SEARCH_CACHE_TTL, () => requestText(url, { referer: `${BASE_URL}/` }));
+    const parsed = parseCategoryList(html);
+    await OmniBox.log("info", `[毒舌影视][search] wd=${wd} page=${page} count=${parsed.list.length}`);
+    return {
+      page,
+      pagecount: parsed.pagecount || page,
+      limit: parsed.list.length,
+      total: parsed.list.length,
+      list: parsed.list,
+    };
+  } catch (e) {
+    await OmniBox.log("error", `[毒舌影视][search] failed: ${e.message || e}`);
+    return {
+      page: Number(params.page || 1) || 1,
+      pagecount: 1,
+      limit: 0,
+      total: 0,
+      list: [],
+    };
+  }
+}
+
+async function play(params = {}) {
+  try {
+    const playId = String(params.playId || params.id || "").trim();
+    if (!playId) return { parse: 0, url: "", urls: [], header: {} };
+
+    if (/\.(m3u8|mp4)(\?|#|$)/i.test(playId)) {
+      const url = resolvePlayUrl(playId);
+      return { parse: 0, url, urls: [{ name: "播放", url }], header: {} };
+    }
+
+    const cacheKey = `dushe:play:${playId}`;
+    const resolved = await getCachedText(cacheKey, PLAY_CACHE_TTL, async () => {
+      const absolutePlayId = absUrl(playId);
+      if (/\/dsshiyipy\//.test(absolutePlayId)) {
+        const url = await resolvePlayPage(absolutePlayId, `${BASE_URL}/`);
+        return url || "";
+      }
+      if (/\/dsshiyidt\//.test(absolutePlayId)) {
+        const detailHtml = await requestText(absolutePlayId);
+        const vod = parseDetail(detailHtml, absolutePlayId);
+        const first = vod?.vod_play_sources?.[0]?.episodes?.[0]?.playId || "";
+        if (first && first !== absolutePlayId) {
+          if (/\.(m3u8|mp4)(\?|#|$)/i.test(first)) return resolvePlayUrl(first);
+          if (/\/dsshiyipy\//.test(first)) {
+            const url = await resolvePlayPage(first, absolutePlayId);
+            return url || first;
+          }
+          return first;
+        }
+      }
+      return "";
+    });
+
+    if (resolved) {
+      const url = resolvePlayUrl(resolved);
+      await OmniBox.log("info", `[毒舌影视][play] parse=0 url=${url}`);
+      return { parse: 0, url, urls: [{ name: "播放", url }], header: {} };
+    }
+
+    const fallback = absUrl(playId);
+    await OmniBox.log("warn", `[毒舌影视][play] fallback parse=1 url=${fallback}`);
+    return { parse: 1, url: fallback, urls: [{ name: "播放", url: fallback }], header: {} };
+  } catch (e) {
+    await OmniBox.log("error", `[毒舌影视][play] failed: ${e.message || e}`);
+    return { parse: 0, url: "", urls: [], header: {} };
+  }
+}


### PR DESCRIPTION
## 变更内容
- 新增 `影视/采集/毒舌影视.js`
- 默认站点地址改为 `https://m.xnhrsb.com`
- 接入首页、分类、详情、搜索、播放五方法
- 兼容宿主常见传参：`categoryId / type_id / tid`、`videoId / vod_id / id`
- 修正首页分类展示结构，补齐 `filters`
- 过滤详情选集中的 `APP秒播`

## 验证
- `node --check 影视/采集/毒舌影视.js`

## 说明
- RR电影相关改动已撤回并恢复到与 `main` 一致版本
- 当前 PR 以 `毒舌影视.js` 为准
