### PR TITLE
feat: 升级人人电影搜索并接入 FlareSolverr

### DIFF
--- a/影视/网盘/人人电影.py
+++ b/影视/网盘/人人电影.py
@@ -2,7 +2,7 @@
 # @name 人人电影
 # @author 梦
 # @description 影视站：https://www.rrdynb.com/ ，支持首页、分类、搜索、详情与网盘线路提取（Python版）
-# @version 1.1.3
+# @version 1.1.4
 # @downloadURL https://gh-proxy.org/https://github.com/Silent1566/OmniBox-Spider/raw/refs/heads/main/影视/网盘/人人电影.py
 
 import json
@@ -93,6 +93,16 @@ def clean_multiline_html(text: str) -> str:
     value = re.sub(r"[ \t\r\f\v]+", " ", value)
     value = re.sub(r"\n\s*\n+", "\n", value)
     return value.strip()
+
+
+def normalize_vod_title(text: str) -> str:
+    value = str(text or "")
+    value = re.sub(r"</?font[^>]*>", "", value, flags=re.I)
+    value = clean_html(value)
+    value = re.split(r"(?:百度云|百度网盘|夸克|阿里云盘|阿里网盘|网盘下载|下载|中字)", value, maxsplit=1)[0].strip()
+    value = value.strip("《》[]【】()（） ")
+    value = re.sub(r"\s+", "", value)
+    return value or clean_html(text)
 
 
 def uniq(seq):
@@ -539,7 +549,7 @@ def extract_cards(text: str, type_id: str, type_name: str):
         href = abs_url(href_m.group(1)) if href_m else ""
         if not href:
             continue
-        title = clean_html(title_m.group(1) if title_m else "")
+        title = normalize_vod_title(title_m.group(1) if title_m else "")
         brief = clean_html(brief_m.group(1) if brief_m else "")
         date = clean_html(date_m.group(1) if date_m else "")
         remarks = " | ".join([x for x in [date, f"豆瓣{clean_html(douban_m.group(1))}" if douban_m else "", f"IMDB{clean_html(imdb_m.group(1))}" if imdb_m else ""] if x])

--- a/影视/网盘/人人电影.py
+++ b/影视/网盘/人人电影.py
@@ -2,7 +2,7 @@
 # @name 人人电影
 # @author 梦
 # @description 影视站：https://www.rrdynb.com/ ，支持首页、分类、搜索、详情与网盘线路提取（Python版）
-# @version 1.1.8
+# @version 1.1.9
 # @downloadURL https://gh-proxy.org/https://github.com/Silent1566/OmniBox-Spider/raw/refs/heads/main/影视/网盘/人人电影.py
 
 import json
@@ -12,13 +12,36 @@ import re
 from urllib.parse import quote
 from spider_runner import OmniBox, run
 
+
+def split_config_list(value: str):
+    return [item.strip() for item in str(value or "").replace(",", ";").split(";") if item.strip()]
+
+
+# ==================== 配置区域开始 ====================
+# 站点基础地址。
 BASE_URL = "https://www.rrdynb.com"
+# 站点请求默认 User-Agent。
 UA = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/135.0.0.0 Safari/537.36"
+
+# FlareSolverr 服务地址。留空表示不启用，需通过环境变量显式配置。
 RRDYNB_FLARESOLVERR_URL = str(os.environ.get("RRDYNB_FLARESOLVERR_URL") or "").strip()
+# FlareSolverr 会话名。用于复用已过验证的浏览器会话。
 RRDYNB_FLARESOLVERR_SESSION = str(os.environ.get("RRDYNB_FLARESOLVERR_SESSION") or "rrdynb-search").strip()
+# FlareSolverr 单次请求最大等待时间（毫秒）。
 RRDYNB_FLARESOLVERR_TIMEOUT_MS = max(10000, int(os.environ.get("RRDYNB_FLARESOLVERR_TIMEOUT_MS", "60000") or 60000))
+# 是否启用 FlareSolverr 搜索链路。
 RRDYNB_SEARCH_USE_FLARESOLVERR = str(os.environ.get("RRDYNB_SEARCH_USE_FLARESOLVERR", "true")).lower() == "true"
 
+# 网盘类型白名单。命中这些类型时才启用多线路（本地代理/服务端代理/直连）策略。
+DRIVE_TYPE_CONFIG = [item.lower() for item in split_config_list(os.environ.get("DRIVE_TYPE_CONFIG", "quark;uc"))]
+# 多线路展示名配置，默认顺序：本地代理 / 服务端代理 / 直连。
+SOURCE_NAMES_CONFIG = split_config_list(os.environ.get("SOURCE_NAMES_CONFIG", "本地代理;服务端代理;直连"))
+# 是否强制允许服务端代理；默认仅在宿主 baseURL 为私网时自动允许。
+EXTERNAL_SERVER_PROXY_ENABLED = str(os.environ.get("EXTERNAL_SERVER_PROXY_ENABLED", "false")).lower() == "true"
+# 网盘源排序优先级。
+DRIVE_ORDER = [item.lower() for item in split_config_list(os.environ.get("DRIVE_ORDER", "baidu;tianyi;quark;uc;115;xunlei;ali;123pan"))]
+
+# 分类映射配置。
 CATEGORY_MAP = {
     "movie": {"type_id": "2", "type_name": "电影", "path": "/movie/"},
     "tv": {"type_id": "6", "type_name": "电视剧", "path": "/dianshiju/"},
@@ -26,18 +49,11 @@ CATEGORY_MAP = {
     "anime": {"type_id": "13", "type_name": "动漫", "path": "/dongman/"},
 }
 TYPEID_TO_KEY = {v["type_id"]: k for k, v in CATEGORY_MAP.items()}
+# 可识别的视频扩展名。
 VIDEO_EXTS = (".mp4", ".mkv", ".avi", ".mov", ".wmv", ".flv", ".m4v", ".ts", ".m2ts", ".webm", ".mpg", ".mpeg")
+# SDK 缓存默认 TTL（秒）。
 CACHE_EX_SECONDS = 3600
-
-
-def split_config_list(value: str):
-    return [item.strip() for item in str(value or "").replace(",", ";").split(";") if item.strip()]
-
-
-DRIVE_TYPE_CONFIG = [item.lower() for item in split_config_list(os.environ.get("DRIVE_TYPE_CONFIG", "quark;uc"))]
-SOURCE_NAMES_CONFIG = split_config_list(os.environ.get("SOURCE_NAMES_CONFIG", "本地代理;服务端代理;直连"))
-EXTERNAL_SERVER_PROXY_ENABLED = str(os.environ.get("EXTERNAL_SERVER_PROXY_ENABLED", "false")).lower() == "true"
-DRIVE_ORDER = [item.lower() for item in split_config_list(os.environ.get("DRIVE_ORDER", "baidu;tianyi;quark;uc;115;xunlei;ali;123pan"))]
+# ==================== 配置区域结束 ====================
 
 
 def abs_url(url: str) -> str:

--- a/影视/网盘/人人电影.py
+++ b/影视/网盘/人人电影.py
@@ -2,7 +2,7 @@
 # @name 人人电影
 # @author 梦
 # @description 影视站：https://www.rrdynb.com/ ，支持首页、分类、搜索、详情与网盘线路提取（Python版）
-# @version 1.1.5
+# @version 1.1.6
 # @downloadURL https://gh-proxy.org/https://github.com/Silent1566/OmniBox-Spider/raw/refs/heads/main/影视/网盘/人人电影.py
 
 import json
@@ -543,6 +543,7 @@ def extract_cards(text: str, type_id: str, type_name: str):
     for block in CARD_RE.findall(text):
         href_m = re.search(r'<a[^>]+class="movie-thumbnails"[^>]+href="([^"]+)"', block, re.I)
         title_m = re.search(r'<h2>\s*<a[^>]+title="([^"]+)"', block, re.S | re.I)
+        title_html_m = re.search(r'<h2>\s*<a[^>]*>(.*?)</a>', block, re.S | re.I)
         img_m = re.search(r'<img[^>]+(?:data-original|src)="([^"]+)"', block, re.I)
         brief_m = re.search(r'<div\s+class="brief"[^>]*>(.*?)</div>', block, re.S | re.I)
         date_m = re.search(r'<div\s+class="tags"[^>]*>\s*([^<\n\r]+)', block, re.S | re.I)
@@ -551,7 +552,10 @@ def extract_cards(text: str, type_id: str, type_name: str):
         href = abs_url(href_m.group(1)) if href_m else ""
         if not href:
             continue
-        title = normalize_vod_title(title_m.group(1) if title_m else "")
+        raw_title = title_m.group(1) if title_m else ""
+        if not raw_title and title_html_m:
+            raw_title = title_html_m.group(1)
+        title = normalize_vod_title(raw_title)
         brief = clean_html(brief_m.group(1) if brief_m else "")
         date = clean_html(date_m.group(1) if date_m else "")
         remarks = " | ".join([x for x in [date, f"豆瓣{clean_html(douban_m.group(1))}" if douban_m else "", f"IMDB{clean_html(imdb_m.group(1))}" if imdb_m else ""] if x])

--- a/影视/网盘/人人电影.py
+++ b/影视/网盘/人人电影.py
@@ -2,7 +2,7 @@
 # @name 人人电影
 # @author 梦
 # @description 影视站：https://www.rrdynb.com/ ，支持首页、分类、搜索、详情与网盘线路提取（Python版）
-# @version 1.1.2
+# @version 1.1.3
 # @downloadURL https://gh-proxy.org/https://github.com/Silent1566/OmniBox-Spider/raw/refs/heads/main/影视/网盘/人人电影.py
 
 import json
@@ -14,6 +14,10 @@ from spider_runner import OmniBox, run
 
 BASE_URL = "https://www.rrdynb.com"
 UA = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/135.0.0.0 Safari/537.36"
+RRDYNB_FLARESOLVERR_URL = str(os.environ.get("RRDYNB_FLARESOLVERR_URL") or "http://192.168.50.50:8191/v1").strip()
+RRDYNB_FLARESOLVERR_SESSION = str(os.environ.get("RRDYNB_FLARESOLVERR_SESSION") or "rrdynb-search").strip()
+RRDYNB_FLARESOLVERR_TIMEOUT_MS = max(10000, int(os.environ.get("RRDYNB_FLARESOLVERR_TIMEOUT_MS", "60000") or 60000))
+RRDYNB_SEARCH_USE_FLARESOLVERR = str(os.environ.get("RRDYNB_SEARCH_USE_FLARESOLVERR", "true")).lower() == "true"
 
 CATEGORY_MAP = {
     "movie": {"type_id": "2", "type_name": "电影", "path": "/movie/"},
@@ -124,6 +128,50 @@ async def request_text(url: str, referer: str = None) -> str:
     if status != 200:
         raise RuntimeError(f"HTTP {status} @ {url}")
     return text
+
+
+async def request_text_via_flaresolverr(url: str, referer: str = None) -> str:
+    if not RRDYNB_FLARESOLVERR_URL:
+        raise RuntimeError("FlareSolverr URL not configured")
+
+    payload = {
+        "cmd": "request.get",
+        "url": url,
+        "maxTimeout": RRDYNB_FLARESOLVERR_TIMEOUT_MS,
+        "session": RRDYNB_FLARESOLVERR_SESSION,
+        "headers": {
+            "User-Agent": UA,
+            "Referer": referer or f"{BASE_URL}/",
+            "Accept-Language": "zh-CN,zh;q=0.9,en;q=0.8",
+        },
+    }
+    await log("info", f"[rrdynb][flaresolverr] url={url} session={RRDYNB_FLARESOLVERR_SESSION}")
+    res = await OmniBox.request(RRDYNB_FLARESOLVERR_URL, {
+        "method": "POST",
+        "headers": {
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        },
+        "body": json.dumps(payload, ensure_ascii=False),
+    })
+    status = int(res.get("statusCode") or 0)
+    body = res.get("body", "")
+    text = body.decode("utf-8", "ignore") if isinstance(body, (bytes, bytearray)) else str(body or "")
+    if status != 200:
+        raise RuntimeError(f"FlareSolverr HTTP {status}")
+
+    data = json.loads(text or "{}")
+    if str(data.get("status") or "").lower() != "ok":
+        raise RuntimeError(f"FlareSolverr status={data.get('status')} message={data.get('message')}")
+
+    solution = data.get("solution") or {}
+    solution_status = int(solution.get("status") or 0)
+    response_text = str(solution.get("response") or "")
+    if solution_status != 200:
+        raise RuntimeError(f"FlareSolverr solution HTTP {solution_status} @ {url}")
+    if not response_text:
+        raise RuntimeError(f"FlareSolverr empty response @ {url}")
+    return response_text
 
 
 async def get_cached_json(key: str):
@@ -653,7 +701,15 @@ async def search(params, context):
         if page > 1:
             return {"page": page, "pagecount": 1, "total": 0, "list": []}
         url = f"{BASE_URL}/plus/search.php?q={quote(keyword)}&pagesize=10"
-        text = await request_text(url, referer=f"{BASE_URL}/")
+        if RRDYNB_SEARCH_USE_FLARESOLVERR:
+            try:
+                text = await request_text_via_flaresolverr(url, referer=f"{BASE_URL}/")
+                await log("info", f"[rrdynb][search] flaresolverr hit len={len(text)}")
+            except Exception as fs_err:
+                await log("warn", f"[rrdynb][search] flaresolverr failed: {fs_err}")
+                text = await request_text(url, referer=f"{BASE_URL}/")
+        else:
+            text = await request_text(url, referer=f"{BASE_URL}/")
         merged = []
         for cfg in CATEGORY_MAP.values():
             merged.extend(extract_cards(text, cfg["type_id"], cfg["type_name"]))

--- a/影视/网盘/人人电影.py
+++ b/影视/网盘/人人电影.py
@@ -2,7 +2,7 @@
 # @name 人人电影
 # @author 梦
 # @description 影视站：https://www.rrdynb.com/ ，支持首页、分类、搜索、详情与网盘线路提取（Python版）
-# @version 1.1.7
+# @version 1.1.8
 # @downloadURL https://gh-proxy.org/https://github.com/Silent1566/OmniBox-Spider/raw/refs/heads/main/影视/网盘/人人电影.py
 
 import json
@@ -14,7 +14,7 @@ from spider_runner import OmniBox, run
 
 BASE_URL = "https://www.rrdynb.com"
 UA = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/135.0.0.0 Safari/537.36"
-RRDYNB_FLARESOLVERR_URL = str(os.environ.get("RRDYNB_FLARESOLVERR_URL") or "http://192.168.50.50:8191/v1").strip()
+RRDYNB_FLARESOLVERR_URL = str(os.environ.get("RRDYNB_FLARESOLVERR_URL") or "").strip()
 RRDYNB_FLARESOLVERR_SESSION = str(os.environ.get("RRDYNB_FLARESOLVERR_SESSION") or "rrdynb-search").strip()
 RRDYNB_FLARESOLVERR_TIMEOUT_MS = max(10000, int(os.environ.get("RRDYNB_FLARESOLVERR_TIMEOUT_MS", "60000") or 60000))
 RRDYNB_SEARCH_USE_FLARESOLVERR = str(os.environ.get("RRDYNB_SEARCH_USE_FLARESOLVERR", "true")).lower() == "true"

--- a/影视/网盘/人人电影.py
+++ b/影视/网盘/人人电影.py
@@ -2,7 +2,7 @@
 # @name 人人电影
 # @author 梦
 # @description 影视站：https://www.rrdynb.com/ ，支持首页、分类、搜索、详情与网盘线路提取（Python版）
-# @version 1.1.4
+# @version 1.1.5
 # @downloadURL https://gh-proxy.org/https://github.com/Silent1566/OmniBox-Spider/raw/refs/heads/main/影视/网盘/人人电影.py
 
 import json
@@ -98,6 +98,8 @@ def clean_multiline_html(text: str) -> str:
 def normalize_vod_title(text: str) -> str:
     value = str(text or "")
     value = re.sub(r"</?font[^>]*>", "", value, flags=re.I)
+    value = re.sub(r"</?fontcolor[^>]*>", "", value, flags=re.I)
+    value = re.sub(r"</?[^>]+>", "", value, flags=re.I)
     value = clean_html(value)
     value = re.split(r"(?:百度云|百度网盘|夸克|阿里云盘|阿里网盘|网盘下载|下载|中字)", value, maxsplit=1)[0].strip()
     value = value.strip("《》[]【】()（） ")

--- a/影视/网盘/人人电影.py
+++ b/影视/网盘/人人电影.py
@@ -2,7 +2,7 @@
 # @name 人人电影
 # @author 梦
 # @description 影视站：https://www.rrdynb.com/ ，支持首页、分类、搜索、详情与网盘线路提取（Python版）
-# @version 1.1.6
+# @version 1.1.7
 # @downloadURL https://gh-proxy.org/https://github.com/Silent1566/OmniBox-Spider/raw/refs/heads/main/影视/网盘/人人电影.py
 
 import json
@@ -97,14 +97,14 @@ def clean_multiline_html(text: str) -> str:
 
 def normalize_vod_title(text: str) -> str:
     value = str(text or "")
+    value = html.unescape(value)
     value = re.sub(r"</?font[^>]*>", "", value, flags=re.I)
     value = re.sub(r"</?fontcolor[^>]*>", "", value, flags=re.I)
     value = re.sub(r"</?[^>]+>", "", value, flags=re.I)
     value = clean_html(value)
     value = re.split(r"(?:百度云|百度网盘|夸克|阿里云盘|阿里网盘|网盘下载|下载|中字)", value, maxsplit=1)[0].strip()
     value = value.strip("《》[]【】()（） ")
-    value = re.sub(r"\s+", "", value)
-    return value or clean_html(text)
+    return value or clean_html(html.unescape(text))
 
 
 def uniq(seq):


### PR DESCRIPTION
## 变更内容
- 升级 `影视/网盘/人人电影.py` 搜索功能，接入 FlareSolverr 过人机验证
- 真实搜索入口改为站点当前使用的 `/plus/search.php?q=关键词&pagesize=10`
- 搜索链路优先走 FlareSolverr，失败时回退普通请求
- 去掉 `RRDYNB_FLARESOLVERR_URL` 的默认值，改为仅在显式配置环境变量时启用
- 美化搜索标题显示：
  - 兼容标准高亮标签、脏标签、转义标签
  - 提取标题完整纯文字
  - 去掉书名号与网盘推广尾巴（如 百度云/夸克/阿里云盘/中字）
- 整理配置区域：
  - 增加“配置区域开始/结束”分隔符
  - 支持环境变量的配置项前置
  - 为配置项补充用途注释

## 新增 / 使用环境变量
- `RRDYNB_FLARESOLVERR_URL`
- `RRDYNB_FLARESOLVERR_SESSION`
- `RRDYNB_FLARESOLVERR_TIMEOUT_MS`
- `RRDYNB_SEARCH_USE_FLARESOLVERR`
- `DRIVE_TYPE_CONFIG`
- `SOURCE_NAMES_CONFIG`
- `EXTERNAL_SERVER_PROXY_ENABLED`
- `DRIVE_ORDER`

## 验证
- `python3 -m py_compile 影视/网盘/人人电影.py`

## 说明
- 本次只涉及 `影视/网盘/人人电影.py`
