### PR TITLE
feat: 升级豆瓣推荐年份筛选并新增2026

### DIFF
--- a/导航/豆瓣推荐.js
+++ b/导航/豆瓣推荐.js
@@ -2,7 +2,7 @@
 // @indexs 1
 // @author lampon
 // @description 豆瓣推荐爬虫脚本
-// @version 1.0.7
+// @version 1.0.8
 // @downloadURL https://gh-proxy.org/https://github.com/Silent1566/OmniBox-Spider/raw/refs/heads/main/导航/豆瓣推荐.js
 
 const OmniBox = require("omnibox_sdk");
@@ -283,7 +283,7 @@ async function home(params, context) {
           init: "", // 默认值：全部（空字符串）
           value: [
             { name: "全部", value: "" },
-            { name: "2020年代", value: "2020年代" },
+            { name: "2026", value: "2026" },
             { name: "2025", value: "2025" },
             { name: "2024", value: "2024" },
             { name: "2023", value: "2023" },
@@ -291,6 +291,7 @@ async function home(params, context) {
             { name: "2021", value: "2021" },
             { name: "2020", value: "2020" },
             { name: "2019", value: "2019" },
+            { name: "2020年代", value: "2020年代" },
             { name: "2010年代", value: "2010年代" },
             { name: "2000年代", value: "2000年代" },
             { name: "90年代", value: "90年代" },
@@ -383,7 +384,7 @@ async function home(params, context) {
           init: "", // 默认值：全部（空字符串）
           value: [
             { name: "全部", value: "" },
-            { name: "2020年代", value: "2020年代" },
+            { name: "2026", value: "2026" },
             { name: "2025", value: "2025" },
             { name: "2024", value: "2024" },
             { name: "2023", value: "2023" },
@@ -391,6 +392,7 @@ async function home(params, context) {
             { name: "2021", value: "2021" },
             { name: "2020", value: "2020" },
             { name: "2019", value: "2019" },
+            { name: "2020年代", value: "2020年代" },
             { name: "2010年代", value: "2010年代" },
             { name: "2000年代", value: "2000年代" },
             { name: "90年代", value: "90年代" },
@@ -486,7 +488,7 @@ async function home(params, context) {
           init: "", // 默认值：全部（空字符串）
           value: [
             { name: "全部", value: "" },
-            { name: "2020年代", value: "2020年代" },
+            { name: "2026", value: "2026" },
             { name: "2025", value: "2025" },
             { name: "2024", value: "2024" },
             { name: "2023", value: "2023" },
@@ -494,6 +496,7 @@ async function home(params, context) {
             { name: "2021", value: "2021" },
             { name: "2020", value: "2020" },
             { name: "2019", value: "2019" },
+            { name: "2020年代", value: "2020年代" },
             { name: "2010年代", value: "2010年代" },
             { name: "2000年代", value: "2000年代" },
             { name: "90年代", value: "90年代" },


### PR DESCRIPTION
## 变更说明
- 升级 `导航/豆瓣推荐.js` 的筛选年份配置
- 在 `movie_filter` / `tv_filter` / `show_filter` 三处年份筛选中新增 `2026`
- 调整年份排序：先展示具体年份，其次展示年代分组，最后保留 `更早`
- 同步将脚本版本从 `1.0.7` 升到 `1.0.8`

## 具体调整
- 年份前置顺序：`2026 -> 2025 -> 2024 -> 2023 -> 2022 -> 2021 -> 2020 -> 2019`
- 年代顺序：`2020年代 -> 2010年代 -> 2000年代 -> 90年代 -> 80年代 -> 70年代 -> 60年代`
- 尾部保留：`更早`

## 验证
- 已执行：`node --check 导航/豆瓣推荐.js`
- 语法检查通过
