### PR TITLE
fix: 修复 LIBVIO 采集线路播放地址解包错误导致 404

### DIFF
--- a/影视/采集/LIBVIO.js
+++ b/影视/采集/LIBVIO.js
@@ -147,11 +147,55 @@ function encodePlayId(payload) {
 }
 
 function decodePlayId(playId = "") {
+    const input = String(playId || "").trim();
+    if (!input) return {};
+
+    // 1) 标准 base64 JSON
     try {
-        return JSON.parse(Buffer.from(playId, "base64").toString("utf8"));
-    } catch {
-        return {};
-    }
+        const text = Buffer.from(input, "base64").toString("utf8").trim();
+        if (text.startsWith("{") && text.endsWith("}")) {
+            return JSON.parse(text);
+        }
+    } catch {}
+
+    // 2) URL-safe base64 JSON（-/_）
+    try {
+        const normalized = input.replace(/-/g, "+").replace(/_/g, "/");
+        const padded = normalized + "=".repeat((4 - (normalized.length % 4)) % 4);
+        const text = Buffer.from(padded, "base64").toString("utf8").trim();
+        if (text.startsWith("{") && text.endsWith("}")) {
+            return JSON.parse(text);
+        }
+    } catch {}
+
+    // 3) 直接 JSON 字符串
+    try {
+        if (input.startsWith("{") && input.endsWith("}")) {
+            return JSON.parse(input);
+        }
+    } catch {}
+
+    return {};
+}
+
+function resolveCollectPlayPageUrl(rawPlayId = "", meta = {}) {
+    const raw = String(rawPlayId || "").trim();
+
+    // 优先用编码后的 meta.url
+    const metaUrl = fixUrl(String(meta?.url || "").trim());
+    if (/^https?:\/\//i.test(metaUrl)) return metaUrl;
+
+    // raw 已是绝对/相对路径
+    if (/^https?:\/\//i.test(raw)) return raw;
+    if (/^\//.test(raw)) return fixUrl(raw);
+    if (/^[^\s]+\.html?(\?.*)?$/i.test(raw)) return fixUrl(`/${raw}`);
+
+    // raw 可能本身是 base64/json 打包过的 playId
+    const nested = decodePlayId(raw);
+    const nestedUrl = fixUrl(String(nested?.url || "").trim());
+    if (/^https?:\/\//i.test(nestedUrl)) return nestedUrl;
+
+    return "";
 }
 
 function buildFilterList(categoryId) {
@@ -689,9 +733,12 @@ async function play(params, context) {
     if (!playId) return emptyPlay(flag);
     try {
         const { main: rawPlayId, meta } = decodeCombinedPlayId(playId);
-        const playPageUrl = rawPlayId;
+        const playPageUrl = resolveCollectPlayPageUrl(rawPlayId, meta);
         const playFlag = String(meta.flag || flag || "LIBVIO");
-        if (!playPageUrl) return emptyPlay(playFlag);
+        if (!playPageUrl) {
+            logInfo("play 无法解析播放页地址", { rawPlayId, flag: playFlag, meta });
+            return emptyPlay(playFlag);
+        }
 
         if (meta.mode === "pan-file") {
             const shareURL = normalizeShareUrl(meta.shareUrl || "");


### PR DESCRIPTION
## 变更说明
- 修复 `影视/采集/LIBVIO.js` 在采集线路播放时把编码后的 `playId` 直接当作站内路径请求，导致 `https://www.libvios.com/eyJ...` 返回 404 的问题。
- `play()` 现在会优先从 `meta.url` 或嵌套解包结果中恢复真实播放页地址（`/play/...html`），不再直接使用原始编码串。

## 关键修复点
- 增强 `decodePlayId()`：支持标准 base64 / URL-safe base64 / 直接 JSON。
- 新增 `resolveCollectPlayPageUrl(rawPlayId, meta)`：统一解析采集线路真实播放页地址。
- `play()` 改为走统一解析函数；解析失败时输出明确日志并安全返回空播放结果。

## 验证
- `node --check 影视/采集/LIBVIO.js`
- 语法检查通过。

## 影响范围
- 仅影响 `LIBVIO` 采集线路播放地址解析流程。
- 网盘线路 (`pan-file`) 逻辑不受影响。
