### PR TITLE
feat: 新增并完善威尔伯TV OmniBox 源

### DIFF
--- a/影视/采集/威尔伯TV.js
+++ b/影视/采集/威尔伯TV.js
@@ -2,7 +2,7 @@
 // @author 梦
 // @description 刮削：已接入，弹幕：未接入，嗅探：直接返回 play.modujx11.com 直链
 // @dependencies cheerio
-// @version 1.0.4
+// @version 1.0.5
 // @downloadURL https://gh-proxy.org/https://github.com/Silent1566/OmniBox-Spider/raw/refs/heads/openclaw/影视/采集/威尔伯TV.js
 
 const OmniBox = require("omnibox_sdk");
@@ -31,6 +31,53 @@ const HOME_SECTION_MARKERS = {
   anime: 'href":"/video/anime"',
   variety: 'href":"/video/variety"',
 };
+
+const FILTERS = {
+  movie: [{ key: "type", name: "按类型", init: "", value: [
+    { name: "全部", value: "" },
+    { name: "喜剧", value: "5" },
+    { name: "爱情", value: "6" },
+    { name: "动作", value: "7" },
+    { name: "犯罪", value: "8" },
+    { name: "科幻", value: "9" },
+    { name: "灾难", value: "11" },
+    { name: "恐怖", value: "12" },
+    { name: "剧情", value: "13" },
+    { name: "战争", value: "14" },
+    { name: "悬疑", value: "15" },
+    { name: "动画", value: "16" },
+    { name: "其他", value: "28" },
+  ] }],
+  tv: [{ key: "type", name: "按类型", init: "", value: [
+    { name: "全部", value: "" },
+    { name: "国产剧", value: "17" },
+    { name: "港台剧", value: "18" },
+    { name: "日韩剧", value: "19" },
+    { name: "欧美剧", value: "20" },
+    { name: "其他剧", value: "21" },
+  ] }],
+  anime: [{ key: "type", name: "按类型", init: "", value: [
+    { name: "全部", value: "" },
+    { name: "国产动漫", value: "22" },
+    { name: "日本动漫", value: "23" },
+    { name: "欧美动漫", value: "29" },
+  ] }],
+  variety: [{ key: "type", name: "按类型", init: "", value: [
+    { name: "全部", value: "" },
+    { name: "国产综艺", value: "24" },
+    { name: "港台综艺", value: "25" },
+    { name: "日韩综艺", value: "26" },
+    { name: "欧美综艺", value: "27" },
+  ] }],
+};
+
+function buildFilters() {
+  const result = {};
+  for (const item of CATEGORY_MAP) {
+    result[item.type_id] = FILTERS[item.type_id] || [];
+  }
+  return result;
+}
 
 module.exports = { home, category, detail, search, play };
 runner.run(module.exports);
@@ -239,11 +286,12 @@ async function home(params, context) {
       }
     }
 
-    await log("info", "home 解析完成", { listCount: list.length, first: list[0] || null });
-    return { class: CATEGORY_MAP, filters: {}, list };
+    const filters = buildFilters();
+    await log("info", "home 解析完成", { listCount: list.length, first: list[0] || null, filterKeys: Object.keys(filters) });
+    return { class: CATEGORY_MAP, filters, list };
   } catch (e) {
     await log("error", "home 失败", { error: e.message });
-    return { class: CATEGORY_MAP, filters: {}, list: [] };
+    return { class: CATEGORY_MAP, filters: buildFilters(), list: [] };
   }
 }
 
@@ -284,11 +332,12 @@ async function category(params, context) {
       page,
       pagecount: page + (list.length >= 12 ? 1 : 0),
       total: list.length,
+      filters: FILTERS[typeId] || [],
       list,
     };
   } catch (e) {
     await log("error", "category 失败", { error: e.message, params });
-    return { page: 1, pagecount: 0, total: 0, list: [] };
+    return { page: 1, pagecount: 0, total: 0, filters: FILTERS[String(params?.categoryId || params?.type_id || params?.type || "movie").trim()] || [], list: [] };
   }
 }
 
@@ -350,7 +399,7 @@ async function search(params, context) {
     return { page, pagecount: page + (list.length >= 12 ? 1 : 0), total: list.length, list };
   } catch (e) {
     await log("error", "search 失败", { error: e.message, params });
-    return { page: 1, pagecount: 0, total: 0, list: [] };
+    return { page: 1, pagecount: 0, total: 0, filters: FILTERS[String(params?.categoryId || params?.type_id || params?.type || "movie").trim()] || [], list: [] };
   }
 }
 

--- a/影视/采集/威尔伯TV.js
+++ b/影视/采集/威尔伯TV.js
@@ -2,7 +2,7 @@
 // @author 梦
 // @description 刮削：已接入，弹幕：未接入，嗅探：直接返回 play.modujx11.com 直链
 // @dependencies cheerio
-// @version 1.0.2
+// @version 1.0.3
 // @downloadURL https://gh-proxy.org/https://github.com/Silent1566/OmniBox-Spider/raw/refs/heads/openclaw/影视/采集/威尔伯TV.js
 
 const OmniBox = require("omnibox_sdk");
@@ -183,8 +183,25 @@ async function home(params, context) {
   await log("info", "home 开始", { params: params || {}, from: context?.from || "web" });
   try {
     const html = await fetchText(`${HOST}/`);
-    await log("info", "home 抓取完成", { htmlLength: html.length, rawVodNameCount: (html.match(/vodName/g) || []).length, rawUrlPrefixCount: (html.match(/urlPrefix/g) || []).length });
-    const list = extractCarouselList(html);
+    const rawVodNameCount = (html.match(/vodName/g) || []).length;
+    const rawUrlPrefixCount = (html.match(/urlPrefix/g) || []).length;
+    const firstVodNameIdx = html.indexOf("vodName");
+    await log("info", "home 抓取完成", { htmlLength: html.length, rawVodNameCount, rawUrlPrefixCount, firstVodNameIdx, firstVodNameSnippet: firstVodNameIdx >= 0 ? html.slice(Math.max(0, firstVodNameIdx - 80), firstVodNameIdx + 220) : "" });
+    let list = extractCarouselList(html);
+    if (!list.length) {
+      const merged = [];
+      const seen = new Set();
+      for (const item of CATEGORY_MAP) {
+        const sectionList = extractSectionList(html, item.type_id);
+        await log("info", "home 分区解析", { typeId: item.type_id, count: sectionList.length, first: sectionList[0] || null });
+        for (const vod of sectionList) {
+          if (!vod?.vod_id || seen.has(vod.vod_id)) continue;
+          seen.add(vod.vod_id);
+          merged.push(vod);
+        }
+      }
+      list = merged.slice(0, 24);
+    }
     await log("info", "home 解析完成", { listCount: list.length, first: list[0] || null });
     return { class: CATEGORY_MAP, filters: {}, list };
   } catch (e) {
@@ -264,7 +281,9 @@ async function search(params, context) {
     const page = Math.max(1, parseInt(params.page || 1, 10));
     if (!keyword) return { page, pagecount: 0, total: 0, list: [] };
     const html = await fetchText(`${HOST}/search?wd=${encodeURIComponent(keyword)}`);
-    await log("info", "search 请求后", { keyword, page, htmlLength: html.length, rawVodNameCount: (html.match(/vodName/g) || []).length });
+    const rawVodNameCount = (html.match(/vodName/g) || []).length;
+    const idx = html.indexOf(keyword);
+    await log("info", "search 请求后", { keyword, page, htmlLength: html.length, rawVodNameCount, keywordIndex: idx, keywordSnippet: idx >= 0 ? html.slice(Math.max(0, idx - 80), idx + 220) : "" });
     const list = extractSectionList(html, "movie");
     await log("info", "search 解析结果", { keyword, page, listCount: list.length, first: list[0] || null });
     return { page, pagecount: page + (list.length >= 12 ? 1 : 0), total: list.length, list };

--- a/影视/采集/威尔伯TV.js
+++ b/影视/采集/威尔伯TV.js
@@ -2,7 +2,7 @@
 // @author 梦
 // @description 刮削：已接入，弹幕：未接入，嗅探：直接返回 play.modujx11.com 直链
 // @dependencies cheerio
-// @version 1.0.5
+// @version 1.0.6
 // @downloadURL https://gh-proxy.org/https://github.com/Silent1566/OmniBox-Spider/raw/refs/heads/openclaw/影视/采集/威尔伯TV.js
 
 const OmniBox = require("omnibox_sdk");
@@ -32,43 +32,106 @@ const HOME_SECTION_MARKERS = {
   variety: 'href":"/video/variety"',
 };
 
+const COMMON_LANG_FILTER = { key: "lang", name: "按语言", init: "", value: [
+  { name: "全部", value: "" },
+  { name: "国语", value: "1" },
+  { name: "粤语", value: "2" },
+  { name: "英语", value: "3" },
+  { name: "韩语", value: "4" },
+  { name: "日语", value: "5" },
+  { name: "西班牙语", value: "6" },
+  { name: "法语", value: "7" },
+  { name: "意大利语", value: "8" },
+  { name: "泰国", value: "9" },
+  { name: "其他", value: "10" },
+] };
+
+const COMMON_AREA_FILTER = { key: "area", name: "按地区", init: "", value: [
+  { name: "全部", value: "" },
+  { name: "大陆", value: "1" },
+  { name: "香港", value: "2" },
+  { name: "台湾", value: "3" },
+  { name: "日本", value: "4" },
+  { name: "韩国", value: "5" },
+  { name: "欧美", value: "6" },
+  { name: "英国", value: "7" },
+  { name: "泰国", value: "8" },
+  { name: "其他", value: "9" },
+] };
+
+const COMMON_YEAR_FILTER = { key: "year", name: "按年份", init: "", value: [
+  { name: "全部", value: "" },
+  { name: "今年", value: "this-year" },
+  { name: "去年", value: "last-year" },
+  { name: "更早", value: "earlier" },
+] };
+
+const COMMON_ORDER_FILTER = { key: "order", name: "排序", init: "created-at", value: [
+  { name: "按时间", value: "created-at" },
+  { name: "按人气", value: "most-view" },
+] };
+
 const FILTERS = {
-  movie: [{ key: "type", name: "按类型", init: "", value: [
-    { name: "全部", value: "" },
-    { name: "喜剧", value: "5" },
-    { name: "爱情", value: "6" },
-    { name: "动作", value: "7" },
-    { name: "犯罪", value: "8" },
-    { name: "科幻", value: "9" },
-    { name: "灾难", value: "11" },
-    { name: "恐怖", value: "12" },
-    { name: "剧情", value: "13" },
-    { name: "战争", value: "14" },
-    { name: "悬疑", value: "15" },
-    { name: "动画", value: "16" },
-    { name: "其他", value: "28" },
-  ] }],
-  tv: [{ key: "type", name: "按类型", init: "", value: [
-    { name: "全部", value: "" },
-    { name: "国产剧", value: "17" },
-    { name: "港台剧", value: "18" },
-    { name: "日韩剧", value: "19" },
-    { name: "欧美剧", value: "20" },
-    { name: "其他剧", value: "21" },
-  ] }],
-  anime: [{ key: "type", name: "按类型", init: "", value: [
-    { name: "全部", value: "" },
-    { name: "国产动漫", value: "22" },
-    { name: "日本动漫", value: "23" },
-    { name: "欧美动漫", value: "29" },
-  ] }],
-  variety: [{ key: "type", name: "按类型", init: "", value: [
-    { name: "全部", value: "" },
-    { name: "国产综艺", value: "24" },
-    { name: "港台综艺", value: "25" },
-    { name: "日韩综艺", value: "26" },
-    { name: "欧美综艺", value: "27" },
-  ] }],
+  movie: [
+    { key: "type", name: "按类型", init: "", value: [
+      { name: "全部", value: "" },
+      { name: "喜剧", value: "5" },
+      { name: "爱情", value: "6" },
+      { name: "动作", value: "7" },
+      { name: "犯罪", value: "8" },
+      { name: "科幻", value: "9" },
+      { name: "灾难", value: "11" },
+      { name: "恐怖", value: "12" },
+      { name: "剧情", value: "13" },
+      { name: "战争", value: "14" },
+      { name: "悬疑", value: "15" },
+      { name: "动画", value: "16" },
+      { name: "其他", value: "28" },
+    ] },
+    COMMON_LANG_FILTER,
+    COMMON_AREA_FILTER,
+    COMMON_YEAR_FILTER,
+    COMMON_ORDER_FILTER,
+  ],
+  tv: [
+    { key: "type", name: "按类型", init: "", value: [
+      { name: "全部", value: "" },
+      { name: "国产剧", value: "17" },
+      { name: "港台剧", value: "18" },
+      { name: "日韩剧", value: "19" },
+      { name: "欧美剧", value: "20" },
+      { name: "其他剧", value: "21" },
+    ] },
+    COMMON_LANG_FILTER,
+    COMMON_AREA_FILTER,
+    COMMON_YEAR_FILTER,
+    COMMON_ORDER_FILTER,
+  ],
+  anime: [
+    { key: "type", name: "按类型", init: "", value: [
+      { name: "全部", value: "" },
+      { name: "国产动漫", value: "22" },
+      { name: "日本动漫", value: "23" },
+      { name: "欧美动漫", value: "29" },
+    ] },
+    COMMON_LANG_FILTER,
+    COMMON_AREA_FILTER,
+    COMMON_YEAR_FILTER,
+    COMMON_ORDER_FILTER,
+  ],
+  variety: [
+    { key: "type", name: "按类型", init: "", value: [
+      { name: "全部", value: "" },
+      { name: "国产综艺", value: "24" },
+      { name: "港台综艺", value: "25" },
+      { name: "日韩综艺", value: "26" },
+      { name: "欧美综艺", value: "27" },
+    ] },
+    COMMON_LANG_FILTER,
+    COMMON_AREA_FILTER,
+    COMMON_YEAR_FILTER,
+    COMMON_ORDER_FILTER,
+  ],
 };
 
 function buildFilters() {

--- a/影视/采集/威尔伯TV.js
+++ b/影视/采集/威尔伯TV.js
@@ -2,7 +2,7 @@
 // @author 梦
 // @description 刮削：已接入，弹幕：未接入，嗅探：直接返回 play.modujx11.com 直链
 // @dependencies cheerio
-// @version 1.0.3
+// @version 1.0.4
 // @downloadURL https://gh-proxy.org/https://github.com/Silent1566/OmniBox-Spider/raw/refs/heads/openclaw/影视/采集/威尔伯TV.js
 
 const OmniBox = require("omnibox_sdk");
@@ -143,14 +143,47 @@ function extractSectionList(html, typeId) {
   return extractGridListFromText(sectionText, urlPrefix);
 }
 
-function buildDetailResult(html, vodId) {
+function mergeHomeSections(html) {
+  const merged = [];
+  const seen = new Set();
+  for (const item of CATEGORY_MAP) {
+    const sectionList = extractSectionList(html, item.type_id);
+    for (const vod of sectionList) {
+      if (!vod?.vod_id || seen.has(vod.vod_id)) continue;
+      seen.add(vod.vod_id);
+      merged.push(vod);
+    }
+  }
+  return merged;
+}
+
+function pickTypeFromId(typeId) {
+  return CATEGORY_MAP.find((item) => item.type_id === typeId)?.type_name || "";
+}
+
+function extractInfoTokens(text) {
+  const match = text.match(/className":"text-gray-1 text-sm","children":\[(.*?)\]\}/);
+  if (!match) return [];
+  return [...match[1].matchAll(/"([^"]*)"/g)]
+    .map((m) => clean(m[1]))
+    .filter((item) => item && item !== "·");
+}
+
+function buildDetailResult(html, vodId, typeId) {
   const $ = cheerio.load(html);
   const text = decodeRsc(html);
   const title = clean($("title").text()).replace(/\s+在线观看.*$/, "") || clean($("meta[property='og:title']").attr("content"));
   const poster = absUrl($("meta[property='og:image']").attr("content"));
-  const content = clean($("meta[property='og:description']").attr("content") || $("meta[name='description']").attr("content") || "");
-  const director = clean($("a[href*='google.com/search?q=导演:']").text() || "");
-  const infoLine = clean($(".space-y-2 p.text-gray-1").first().text());
+  const contentMatch = text.match(/"vodContent":"([^"]*)"/);
+  const content = clean(contentMatch?.[1] || $("meta[property='og:description']").attr("content") || $("meta[name='description']").attr("content") || "");
+  const directorMatch = text.match(/q=导演:([^"&]+)["&]/);
+  const director = clean(directorMatch?.[1] || $("a[href*='google.com/search?q=导演:']").text() || "");
+  const infoTokens = extractInfoTokens(text);
+  const vodYear = infoTokens.find((item) => /^\d{4}$/.test(item)) || "";
+  const maybeLang = infoTokens.filter((item) => !/^\d{4}$/.test(item));
+  const typeName = maybeLang[0] || pickTypeFromId(typeId) || "";
+  const lang = maybeLang[maybeLang.length - 1] || "";
+  const infoLine = [typeName, vodYear, lang].filter(Boolean).join(" · ");
 
   const playUrlMatch = text.match(/https:\/\/play\.modujx11\.com\/[^"\s]+\.m3u8/);
   const episodeMatches = [...text.matchAll(/([^"\[]+)\$(https:\/\/play\.modujx11\.com\/[^"\s]+\.m3u8)/g)];
@@ -171,6 +204,8 @@ function buildDetailResult(html, vodId) {
     vod_id: String(vodId || ""),
     vod_name: title,
     vod_pic: poster,
+    type_name: typeName,
+    vod_year: vodYear,
     vod_content: content,
     vod_actor: "",
     vod_director: director || "",
@@ -186,22 +221,24 @@ async function home(params, context) {
     const rawVodNameCount = (html.match(/vodName/g) || []).length;
     const rawUrlPrefixCount = (html.match(/urlPrefix/g) || []).length;
     const firstVodNameIdx = html.indexOf("vodName");
-    await log("info", "home 抓取完成", { htmlLength: html.length, rawVodNameCount, rawUrlPrefixCount, firstVodNameIdx, firstVodNameSnippet: firstVodNameIdx >= 0 ? html.slice(Math.max(0, firstVodNameIdx - 80), firstVodNameIdx + 220) : "" });
+    await log("info", "home 抓取完成", {
+      htmlLength: html.length,
+      rawVodNameCount,
+      rawUrlPrefixCount,
+      firstVodNameIdx,
+      firstVodNameSnippet: firstVodNameIdx >= 0 ? html.slice(Math.max(0, firstVodNameIdx - 80), firstVodNameIdx + 220) : "",
+    });
+
     let list = extractCarouselList(html);
+    await log("info", "home 轮播解析", { listCount: list.length, first: list[0] || null });
     if (!list.length) {
-      const merged = [];
-      const seen = new Set();
+      list = mergeHomeSections(html).slice(0, 24);
       for (const item of CATEGORY_MAP) {
         const sectionList = extractSectionList(html, item.type_id);
         await log("info", "home 分区解析", { typeId: item.type_id, count: sectionList.length, first: sectionList[0] || null });
-        for (const vod of sectionList) {
-          if (!vod?.vod_id || seen.has(vod.vod_id)) continue;
-          seen.add(vod.vod_id);
-          merged.push(vod);
-        }
       }
-      list = merged.slice(0, 24);
     }
+
     await log("info", "home 解析完成", { listCount: list.length, first: list[0] || null });
     return { class: CATEGORY_MAP, filters: {}, list };
   } catch (e) {
@@ -265,8 +302,16 @@ async function detail(params, context) {
     await log("info", "detail 请求前", { url, vodId, typeId });
     const html = await fetchText(url);
     await log("info", "detail 请求后", { url, htmlLength: html.length, m3u8Count: (html.match(/play\.modujx11\.com/g) || []).length });
-    const vod = buildDetailResult(html, vodId);
-    await log("info", "detail 解析完成", { vodId, sourceCount: vod.vod_play_sources.length, episodeCount: vod.vod_play_sources.reduce((n, s) => n + (s.episodes || []).length, 0) });
+    const vod = buildDetailResult(html, vodId, typeId);
+    await log("info", "detail 解析完成", {
+      vodId,
+      vodName: vod.vod_name,
+      remarks: vod.vod_remarks,
+      director: vod.vod_director,
+      contentLength: (vod.vod_content || '').length,
+      sourceCount: vod.vod_play_sources.length,
+      episodeCount: vod.vod_play_sources.reduce((n, s) => n + (s.episodes || []).length, 0),
+    });
     return { list: [vod] };
   } catch (e) {
     await log("error", "detail 失败", { error: e.message, params });
@@ -280,11 +325,27 @@ async function search(params, context) {
     const keyword = String(params.keyword || params.wd || params.key || "").trim();
     const page = Math.max(1, parseInt(params.page || 1, 10));
     if (!keyword) return { page, pagecount: 0, total: 0, list: [] };
+
     const html = await fetchText(`${HOST}/search?wd=${encodeURIComponent(keyword)}`);
     const rawVodNameCount = (html.match(/vodName/g) || []).length;
     const idx = html.indexOf(keyword);
-    await log("info", "search 请求后", { keyword, page, htmlLength: html.length, rawVodNameCount, keywordIndex: idx, keywordSnippet: idx >= 0 ? html.slice(Math.max(0, idx - 80), idx + 220) : "" });
-    const list = extractSectionList(html, "movie");
+    await log("info", "search 请求后", {
+      keyword,
+      page,
+      htmlLength: html.length,
+      rawVodNameCount,
+      keywordIndex: idx,
+      keywordSnippet: idx >= 0 ? html.slice(Math.max(0, idx - 80), idx + 220) : "",
+    });
+
+    let list = extractSectionList(html, "movie");
+    if (!list.length) {
+      const homeHtml = await fetchText(`${HOST}/`);
+      const merged = mergeHomeSections(homeHtml);
+      list = merged.filter((item) => String(item.vod_name || '').includes(keyword)).slice(0, 24);
+      await log("info", "search 首页兜底结果", { keyword, page, mergedCount: merged.length, listCount: list.length, first: list[0] || null });
+    }
+
     await log("info", "search 解析结果", { keyword, page, listCount: list.length, first: list[0] || null });
     return { page, pagecount: page + (list.length >= 12 ? 1 : 0), total: list.length, list };
   } catch (e) {

--- a/影视/采集/威尔伯TV.js
+++ b/影视/采集/威尔伯TV.js
@@ -2,7 +2,7 @@
 // @author 梦
 // @description 刮削：已接入，弹幕：未接入，嗅探：直接返回 play.modujx11.com 直链
 // @dependencies cheerio
-// @version 1.0.7
+// @version 1.0.8
 // @downloadURL https://gh-proxy.org/https://github.com/Silent1566/OmniBox-Spider/raw/refs/heads/openclaw/影视/采集/威尔伯TV.js
 
 const OmniBox = require("omnibox_sdk");
@@ -35,29 +35,29 @@ const HOME_SECTION_MARKERS = {
 
 const COMMON_LANG_FILTER = { key: "lang", name: "按语言", init: "", value: [
   { name: "全部", value: "" },
-  { name: "国语", value: "1" },
-  { name: "粤语", value: "2" },
-  { name: "英语", value: "3" },
-  { name: "韩语", value: "4" },
-  { name: "日语", value: "5" },
-  { name: "西班牙语", value: "6" },
-  { name: "法语", value: "7" },
-  { name: "意大利语", value: "8" },
-  { name: "泰国", value: "9" },
-  { name: "其他", value: "10" },
+  { name: "国语", value: "国语" },
+  { name: "粤语", value: "粤语" },
+  { name: "英语", value: "英语" },
+  { name: "韩语", value: "韩语" },
+  { name: "日语", value: "日语" },
+  { name: "西班牙语", value: "西班牙语" },
+  { name: "法语", value: "法语" },
+  { name: "意大利语", value: "意大利语" },
+  { name: "泰国", value: "泰国" },
+  { name: "其他", value: "其他" },
 ] };
 
 const COMMON_AREA_FILTER = { key: "area", name: "按地区", init: "", value: [
   { name: "全部", value: "" },
-  { name: "大陆", value: "1" },
-  { name: "香港", value: "2" },
-  { name: "台湾", value: "3" },
-  { name: "日本", value: "4" },
-  { name: "韩国", value: "5" },
-  { name: "欧美", value: "6" },
-  { name: "英国", value: "7" },
-  { name: "泰国", value: "8" },
-  { name: "其他", value: "9" },
+  { name: "大陆", value: "大陆" },
+  { name: "香港", value: "香港" },
+  { name: "台湾", value: "台湾" },
+  { name: "日本", value: "日本" },
+  { name: "韩国", value: "韩国" },
+  { name: "欧美", value: "欧美" },
+  { name: "英国", value: "英国" },
+  { name: "泰国", value: "泰国" },
+  { name: "其他", value: "其他" },
 ] };
 
 const COMMON_YEAR_FILTER = { key: "year", name: "按年份", init: "", value: [

--- a/影视/采集/威尔伯TV.js
+++ b/影视/采集/威尔伯TV.js
@@ -2,7 +2,7 @@
 // @author 梦
 // @description 刮削：已接入，弹幕：未接入，嗅探：直接返回 play.modujx11.com 直链
 // @dependencies cheerio
-// @version 1.0.1
+// @version 1.0.2
 // @downloadURL https://gh-proxy.org/https://github.com/Silent1566/OmniBox-Spider/raw/refs/heads/openclaw/影视/采集/威尔伯TV.js
 
 const OmniBox = require("omnibox_sdk");
@@ -25,37 +25,48 @@ const CATEGORY_MAP = [
   { type_id: "variety", type_name: "综艺" },
 ];
 
+const HOME_SECTION_MARKERS = {
+  movie: 'href":"/video/movie"',
+  tv: 'href":"/video/tv"',
+  anime: 'href":"/video/anime"',
+  variety: 'href":"/video/variety"',
+};
+
 module.exports = { home, category, detail, search, play };
 runner.run(module.exports);
 
 function log(level, message, data) {
-  const suffix = typeof data === 'undefined' ? '' : ` | ${JSON.stringify(data)}`;
+  const suffix = typeof data === "undefined" ? "" : ` | ${JSON.stringify(data)}`;
   return OmniBox.log(level, `[威尔伯TV] ${message}${suffix}`);
 }
 
 function absUrl(url) {
-  const value = String(url || '').trim();
-  if (!value) return '';
+  const value = String(url || "").trim();
+  if (!value) return "";
   if (/^https?:\/\//i.test(value)) return value;
-  if (value.startsWith('//')) return `https:${value}`;
-  if (value.startsWith('/')) return `${HOST}${value}`;
+  if (value.startsWith("//")) return `https:${value}`;
+  if (value.startsWith("/")) return `${HOST}${value}`;
   return `${HOST}/${value}`;
 }
 
 function clean(text) {
-  return String(text || '')
-    .replace(/<[^>]+>/g, ' ')
-    .replace(/&nbsp;/g, ' ')
-    .replace(/&amp;/g, '&')
-    .replace(/&lt;/g, '<')
-    .replace(/&gt;/g, '>')
-    .replace(/\s+/g, ' ')
+  return String(text || "")
+    .replace(/<[^>]+>/g, " ")
+    .replace(/&nbsp;/g, " ")
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/\s+/g, " ")
     .trim();
+}
+
+function decodeRsc(html) {
+  return String(html || "").replace(/\\"/g, '"');
 }
 
 function fetchText(url, options = {}) {
   return OmniBox.request(url, {
-    method: options.method || 'GET',
+    method: options.method || "GET",
     headers: {
       ...HEADERS,
       ...(options.headers || {}),
@@ -65,19 +76,20 @@ function fetchText(url, options = {}) {
     body: options.body,
   }).then((res) => {
     if (!res || Number(res.statusCode) < 200 || Number(res.statusCode) >= 400) {
-      throw new Error(`HTTP ${res?.statusCode || 'unknown'} @ ${url}`);
+      throw new Error(`HTTP ${res?.statusCode || "unknown"} @ ${url}`);
     }
-    return String(res.body || '');
+    return String(res.body || "");
   });
 }
 
 function extractCarouselList(html) {
+  const text = decodeRsc(html);
   const list = [];
   const seen = new Set();
   const regex = /\{"id":(\d+),"vod":\{"id":(\d+),"vodName":"([^"]+)","vodPic":"([^"]+)","vodRemarks":"([^"]*)"/g;
   let match;
-  while ((match = regex.exec(html)) !== null) {
-    const vodId = String(match[2] || '').trim();
+  while ((match = regex.exec(text)) !== null) {
+    const vodId = String(match[2] || "").trim();
     if (!vodId || seen.has(vodId)) continue;
     seen.add(vodId);
     list.push({
@@ -85,19 +97,19 @@ function extractCarouselList(html) {
       vod_name: clean(match[3]),
       vod_pic: absUrl(match[4]),
       vod_remarks: clean(match[5]),
-      vod_content: '',
+      vod_content: "",
     });
   }
   return list;
 }
 
-function extractGridList(html, urlPrefix) {
+function extractGridListFromText(text, urlPrefix) {
   const list = [];
   const seen = new Set();
   const pattern = /\{"id":(\d+),"vodName":"([^"]+)","vodPic":"([^"]+)","vodRemarks":"([^"]*)"/g;
   let match;
-  while ((match = pattern.exec(html)) !== null) {
-    const vodId = String(match[1] || '').trim();
+  while ((match = pattern.exec(text)) !== null) {
+    const vodId = String(match[1] || "").trim();
     if (!vodId || seen.has(vodId)) continue;
     seen.add(vodId);
     list.push({
@@ -106,71 +118,114 @@ function extractGridList(html, urlPrefix) {
       vod_pic: absUrl(match[3]),
       vod_remarks: clean(match[4]),
       vod_url: `${HOST}${urlPrefix}/${vodId}`,
-      vod_content: '',
+      vod_content: "",
     });
   }
   return list;
 }
 
-function parseCategoryHtml(html) {
-  const urlPrefixMatch = html.match(/"urlPrefix":"\/(movie|tv|anime|variety)"/);
-  const urlPrefix = urlPrefixMatch ? `/${urlPrefixMatch[1]}` : '';
-  if (urlPrefix) {
-    const grid = extractGridList(html, urlPrefix);
-    if (grid.length) return grid;
+function extractSectionList(html, typeId) {
+  const text = decodeRsc(html);
+  const marker = HOME_SECTION_MARKERS[typeId];
+  if (!marker) return [];
+  const start = text.indexOf(marker);
+  if (start < 0) return [];
+
+  let nextStart = text.length;
+  for (const [otherType, otherMarker] of Object.entries(HOME_SECTION_MARKERS)) {
+    if (otherType === typeId) continue;
+    const idx = text.indexOf(otherMarker, start + marker.length);
+    if (idx >= 0 && idx < nextStart) nextStart = idx;
   }
-  return extractCarouselList(html);
+
+  const sectionText = text.slice(start, nextStart);
+  const urlPrefix = `/${typeId}`;
+  return extractGridListFromText(sectionText, urlPrefix);
 }
 
 function buildDetailResult(html, vodId) {
   const $ = cheerio.load(html);
-  const title = clean($('title').text()).replace(/\s+在线观看.*$/, '') || clean($('meta[property="og:title"]').attr('content'));
-  const poster = absUrl($('meta[property="og:image"]').attr('content'));
-  const content = clean($('meta[property="og:description"]').attr('content') || $('meta[name="description"]').attr('content') || '');
-  const director = clean($('a[href*="google.com/search?q=导演:"]').text() || '');
-  const infoLine = clean($('.space-y-2 p.text-gray-1').first().text());
   const text = decodeRsc(html);
+  const title = clean($("title").text()).replace(/\s+在线观看.*$/, "") || clean($("meta[property='og:title']").attr("content"));
+  const poster = absUrl($("meta[property='og:image']").attr("content"));
+  const content = clean($("meta[property='og:description']").attr("content") || $("meta[name='description']").attr("content") || "");
+  const director = clean($("a[href*='google.com/search?q=导演:']").text() || "");
+  const infoLine = clean($(".space-y-2 p.text-gray-1").first().text());
+
   const playUrlMatch = text.match(/https:\/\/play\.modujx11\.com\/[^"\s]+\.m3u8/);
-  const episodeMatch = text.match(/episodes\":\[\"([^\"]+)\"\]/);
+  const episodeMatches = [...text.matchAll(/([^"\[]+)\$(https:\/\/play\.modujx11\.com\/[^"\s]+\.m3u8)/g)];
   const episodes = [];
-  if (episodeMatch) {
-    const [name, url] = String(episodeMatch[1] || '').split('$');
-    if (name && url) episodes.push({ name, playId: url });
+  const seen = new Set();
+  for (const item of episodeMatches) {
+    const name = clean(item[1]);
+    const url = item[2];
+    if (!name || !url || seen.has(`${name}|${url}`)) continue;
+    seen.add(`${name}|${url}`);
+    episodes.push({ name, playId: url });
   }
   if (!episodes.length && playUrlMatch) {
-    episodes.push({ name: '正片', playId: playUrlMatch[1] });
+    episodes.push({ name: "正片", playId: playUrlMatch[0] });
   }
+
   return {
-    vod_id: String(vodId || ''),
+    vod_id: String(vodId || ""),
     vod_name: title,
     vod_pic: poster,
     vod_content: content,
-    vod_actor: '',
-    vod_director: director || '',
+    vod_actor: "",
+    vod_director: director || "",
     vod_remarks: infoLine,
-    vod_play_sources: episodes.length ? [{ name: '正片', episodes }] : [],
+    vod_play_sources: episodes.length ? [{ name: "正片", episodes }] : [],
   };
 }
 
-async function home() {
+async function home(params, context) {
+  await log("info", "home 开始", { params: params || {}, from: context?.from || "web" });
   try {
     const html = await fetchText(`${HOST}/`);
+    await log("info", "home 抓取完成", { htmlLength: html.length, rawVodNameCount: (html.match(/vodName/g) || []).length, rawUrlPrefixCount: (html.match(/urlPrefix/g) || []).length });
     const list = extractCarouselList(html);
+    await log("info", "home 解析完成", { listCount: list.length, first: list[0] || null });
     return { class: CATEGORY_MAP, filters: {}, list };
   } catch (e) {
-    await log('error', 'home 失败', { error: e.message });
+    await log("error", "home 失败", { error: e.message });
     return { class: CATEGORY_MAP, filters: {}, list: [] };
   }
 }
 
-async function category(params) {
+async function category(params, context) {
+  await log("info", "category 开始", { params: params || {}, from: context?.from || "web" });
   try {
-    const typeId = String(params.categoryId || params.type_id || params.type || 'movie');
+    const typeId = String(params.categoryId || params.type_id || params.type || "movie").trim();
     const page = Math.max(1, parseInt(params.page || 1, 10));
-    const subType = String((params.filters && params.filters.type) || params.type || '').trim();
+    const subType = String((params.filters && params.filters.type) || params.type || "").trim();
     const path = subType ? `/video/${typeId}?type=${encodeURIComponent(subType)}` : `/video/${typeId}`;
-    const html = await fetchText(`${HOST}${path}`);
-    const list = parseCategoryHtml(html);
+
+    const categoryHtml = await fetchText(`${HOST}${path}`);
+    await log("info", "category 页面抓取完成", {
+      typeId,
+      page,
+      path,
+      htmlLength: categoryHtml.length,
+      rawVodNameCount: (categoryHtml.match(/vodName/g) || []).length,
+      rawUrlPrefixCount: (categoryHtml.match(/urlPrefix/g) || []).length,
+    });
+
+    let list = extractSectionList(categoryHtml, typeId);
+    await log("info", "category 页面解析结果", { typeId, page, listCount: list.length, first: list[0] || null });
+
+    if (!list.length) {
+      const homeHtml = await fetchText(`${HOST}/`);
+      await log("info", "category 回退首页抓取完成", {
+        typeId,
+        homeHtmlLength: homeHtml.length,
+        homeVodNameCount: (homeHtml.match(/vodName/g) || []).length,
+        homeUrlPrefixCount: (homeHtml.match(/urlPrefix/g) || []).length,
+      });
+      list = extractSectionList(homeHtml, typeId);
+      await log("info", "category 回退首页解析结果", { typeId, page, listCount: list.length, first: list[0] || null });
+    }
+
     return {
       page,
       pagecount: page + (list.length >= 12 ? 1 : 0),
@@ -178,61 +233,62 @@ async function category(params) {
       list,
     };
   } catch (e) {
-    await log('error', 'category 失败', { error: e.message, params });
+    await log("error", "category 失败", { error: e.message, params });
     return { page: 1, pagecount: 0, total: 0, list: [] };
   }
 }
 
-async function detail(params) {
+async function detail(params, context) {
+  await log("info", "detail 开始", { params: params || {}, from: context?.from || "web" });
   try {
-    const vodId = String(params.videoId || params.vod_id || params.id || '').trim();
-    const typeId = String(params.type_id || params.type || 'movie').trim();
+    const vodId = String(params.videoId || params.vod_id || params.id || "").trim();
+    const typeId = String(params.type_id || params.type || "movie").trim();
     if (!vodId) return { list: [] };
-    const html = await fetchText(`${HOST}/video/${typeId}/${vodId}`);
+    const url = `${HOST}/video/${typeId}/${vodId}`;
+    await log("info", "detail 请求前", { url, vodId, typeId });
+    const html = await fetchText(url);
+    await log("info", "detail 请求后", { url, htmlLength: html.length, m3u8Count: (html.match(/play\.modujx11\.com/g) || []).length });
     const vod = buildDetailResult(html, vodId);
+    await log("info", "detail 解析完成", { vodId, sourceCount: vod.vod_play_sources.length, episodeCount: vod.vod_play_sources.reduce((n, s) => n + (s.episodes || []).length, 0) });
     return { list: [vod] };
   } catch (e) {
-    await log('error', 'detail 失败', { error: e.message, params });
+    await log("error", "detail 失败", { error: e.message, params });
     return { list: [] };
   }
 }
 
-async function search(params) {
+async function search(params, context) {
+  await log("info", "search 开始", { params: params || {}, from: context?.from || "web" });
   try {
-    const keyword = String(params.keyword || params.wd || params.key || '').trim();
+    const keyword = String(params.keyword || params.wd || params.key || "").trim();
     const page = Math.max(1, parseInt(params.page || 1, 10));
     if (!keyword) return { page, pagecount: 0, total: 0, list: [] };
     const html = await fetchText(`${HOST}/search?wd=${encodeURIComponent(keyword)}`);
-    const list = [];
-    const re = /\{"id":(\d+),"vodName":"([^"]+)","vodPic":"([^"]+)","vodRemarks":"([^"]*)"/g;
-    let match;
-    while ((match = re.exec(html)) !== null) {
-      list.push({
-        vod_id: String(match[1]),
-        vod_name: clean(match[2]),
-        vod_pic: absUrl(match[3]),
-        vod_remarks: clean(match[4]),
-      });
-    }
+    await log("info", "search 请求后", { keyword, page, htmlLength: html.length, rawVodNameCount: (html.match(/vodName/g) || []).length });
+    const list = extractSectionList(html, "movie");
+    await log("info", "search 解析结果", { keyword, page, listCount: list.length, first: list[0] || null });
     return { page, pagecount: page + (list.length >= 12 ? 1 : 0), total: list.length, list };
   } catch (e) {
-    await log('error', 'search 失败', { error: e.message, params });
+    await log("error", "search 失败", { error: e.message, params });
     return { page: 1, pagecount: 0, total: 0, list: [] };
   }
 }
 
-async function play(params) {
+async function play(params, context) {
+  await log("info", "play 开始", { params: params || {}, from: context?.from || "web" });
   try {
-    const playUrl = String(params.playId || params.url || '').trim();
+    const playUrl = String(params.playId || params.url || "").trim();
     if (!playUrl) return { parse: 0, urls: [] };
-    return {
+    const result = {
       parse: 0,
-      flag: String(params.flag || '威尔伯TV'),
-      header: { Referer: HOST, Origin: HOST, 'User-Agent': UA },
-      urls: [{ name: String(params.name || '正片'), url: playUrl }],
+      flag: String(params.flag || "威尔伯TV"),
+      header: { Referer: HOST, Origin: HOST, "User-Agent": UA },
+      urls: [{ name: String(params.name || "正片"), url: playUrl }],
     };
+    await log("info", "play 完成", { parse: result.parse, urlCount: result.urls.length, first: result.urls[0] || null });
+    return result;
   } catch (e) {
-    await log('error', 'play 失败', { error: e.message, params });
+    await log("error", "play 失败", { error: e.message, params });
     return { parse: 0, urls: [] };
   }
 }

--- a/影视/采集/威尔伯TV.js
+++ b/影视/采集/威尔伯TV.js
@@ -2,7 +2,7 @@
 // @author 梦
 // @description 刮削：已接入，弹幕：未接入，嗅探：直接返回 play.modujx11.com 直链
 // @dependencies cheerio
-// @version 1.0.6
+// @version 1.0.7
 // @downloadURL https://gh-proxy.org/https://github.com/Silent1566/OmniBox-Spider/raw/refs/heads/openclaw/影视/采集/威尔伯TV.js
 
 const OmniBox = require("omnibox_sdk");
@@ -10,6 +10,7 @@ const runner = require("spider_runner");
 const cheerio = require("cheerio");
 
 const HOST = "https://wei2bo.com";
+const API_BASE = "https://api.wei2bo.com/api/v1";
 const UA = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36";
 const HEADERS = {
   "User-Agent": UA,
@@ -19,10 +20,10 @@ const HEADERS = {
 };
 
 const CATEGORY_MAP = [
-  { type_id: "movie", type_name: "电影" },
-  { type_id: "tv", type_name: "电视剧" },
-  { type_id: "anime", type_name: "动漫" },
-  { type_id: "variety", type_name: "综艺" },
+  { type_id: "movie", type_name: "电影", pid: 1 },
+  { type_id: "tv", type_name: "电视剧", pid: 2 },
+  { type_id: "anime", type_name: "动漫", pid: 3 },
+  { type_id: "variety", type_name: "综艺", pid: 4 },
 ];
 
 const HOME_SECTION_MARKERS = {
@@ -134,16 +135,14 @@ const FILTERS = {
   ],
 };
 
-function buildFilters() {
-  const result = {};
-  for (const item of CATEGORY_MAP) {
-    result[item.type_id] = FILTERS[item.type_id] || [];
-  }
-  return result;
-}
-
 module.exports = { home, category, detail, search, play };
 runner.run(module.exports);
+
+function buildFilters() {
+  const result = {};
+  for (const item of CATEGORY_MAP) result[item.type_id] = FILTERS[item.type_id] || [];
+  return result;
+}
 
 function log(level, message, data) {
   const suffix = typeof data === "undefined" ? "" : ` | ${JSON.stringify(data)}`;
@@ -192,6 +191,58 @@ function fetchText(url, options = {}) {
   });
 }
 
+function fetchJson(url, options = {}) {
+  return OmniBox.request(url, {
+    method: options.method || "GET",
+    headers: {
+      "User-Agent": UA,
+      Accept: "application/json, text/plain, */*",
+      Referer: `${HOST}/`,
+      Origin: HOST,
+      ...(options.headers || {}),
+    },
+    timeout: options.timeout || 20000,
+    body: options.body,
+  }).then((res) => {
+    if (!res || Number(res.statusCode) < 200 || Number(res.statusCode) >= 400) {
+      throw new Error(`HTTP ${res?.statusCode || "unknown"} @ ${url}`);
+    }
+    return JSON.parse(String(res.body || "{}"));
+  });
+}
+
+function encodeVodId(typeId, vodId) {
+  return `${typeId}:${vodId}`;
+}
+
+function decodeVodId(rawId = "") {
+  const value = String(rawId || "").trim();
+  if (!value.includes(":")) return { typeId: "", vodId: value };
+  const [typeId, vodId] = value.split(":", 2);
+  return { typeId: typeId || "", vodId: vodId || "" };
+}
+
+function pickCategory(typeId) {
+  return CATEGORY_MAP.find((item) => item.type_id === typeId) || CATEGORY_MAP[0];
+}
+
+function pidToTypeId(pid) {
+  return CATEGORY_MAP.find((item) => Number(item.pid) === Number(pid))?.type_id || "movie";
+}
+
+function mapVodItem(item, fallbackTypeId = "movie") {
+  const typeId = item?.type?.pid ? pidToTypeId(item.type.pid) : fallbackTypeId;
+  const vodId = String(item?.id || "").trim();
+  return {
+    vod_id: encodeVodId(typeId, vodId),
+    vod_name: clean(item?.vodName || ""),
+    vod_pic: absUrl(item?.vodPic || ""),
+    vod_remarks: clean(item?.vodRemarks || ""),
+    vod_url: `${HOST}/video/${typeId}/${vodId}`,
+    vod_content: "",
+  };
+}
+
 function extractCarouselList(html) {
   const text = decodeRsc(html);
   const list = [];
@@ -203,7 +254,7 @@ function extractCarouselList(html) {
     if (!vodId || seen.has(vodId)) continue;
     seen.add(vodId);
     list.push({
-      vod_id: vodId,
+      vod_id: encodeVodId("movie", vodId),
       vod_name: clean(match[3]),
       vod_pic: absUrl(match[4]),
       vod_remarks: clean(match[5]),
@@ -213,7 +264,7 @@ function extractCarouselList(html) {
   return list;
 }
 
-function extractGridListFromText(text, urlPrefix) {
+function extractGridListFromText(text, urlPrefix, typeId) {
   const list = [];
   const seen = new Set();
   const pattern = /\{"id":(\d+),"vodName":"([^"]+)","vodPic":"([^"]+)","vodRemarks":"([^"]*)"/g;
@@ -223,7 +274,7 @@ function extractGridListFromText(text, urlPrefix) {
     if (!vodId || seen.has(vodId)) continue;
     seen.add(vodId);
     list.push({
-      vod_id: vodId,
+      vod_id: encodeVodId(typeId, vodId),
       vod_name: clean(match[2]),
       vod_pic: absUrl(match[3]),
       vod_remarks: clean(match[4]),
@@ -250,7 +301,7 @@ function extractSectionList(html, typeId) {
 
   const sectionText = text.slice(start, nextStart);
   const urlPrefix = `/${typeId}`;
-  return extractGridListFromText(sectionText, urlPrefix);
+  return extractGridListFromText(sectionText, urlPrefix, typeId);
 }
 
 function mergeHomeSections(html) {
@@ -265,10 +316,6 @@ function mergeHomeSections(html) {
     }
   }
   return merged;
-}
-
-function pickTypeFromId(typeId) {
-  return CATEGORY_MAP.find((item) => item.type_id === typeId)?.type_name || "";
 }
 
 function extractInfoTokens(text) {
@@ -291,7 +338,7 @@ function buildDetailResult(html, vodId, typeId) {
   const infoTokens = extractInfoTokens(text);
   const vodYear = infoTokens.find((item) => /^\d{4}$/.test(item)) || "";
   const maybeLang = infoTokens.filter((item) => !/^\d{4}$/.test(item));
-  const typeName = maybeLang[0] || pickTypeFromId(typeId) || "";
+  const typeName = maybeLang[0] || pickCategory(typeId).type_name || "";
   const lang = maybeLang[maybeLang.length - 1] || "";
   const infoLine = [typeName, vodYear, lang].filter(Boolean).join(" · ");
 
@@ -311,7 +358,7 @@ function buildDetailResult(html, vodId, typeId) {
   }
 
   return {
-    vod_id: String(vodId || ""),
+    vod_id: encodeVodId(typeId, vodId),
     vod_name: title,
     vod_pic: poster,
     type_name: typeName,
@@ -322,6 +369,34 @@ function buildDetailResult(html, vodId, typeId) {
     vod_remarks: infoLine,
     vod_play_sources: episodes.length ? [{ name: "正片", episodes }] : [],
   };
+}
+
+async function fetchCategoryApi(typeId, page, filters = {}) {
+  const category = pickCategory(typeId);
+  const qs = new URLSearchParams();
+  qs.set("page", String(page || 1));
+  qs.set("pid", String(category.pid));
+  if (filters.type) qs.set("typeId", String(filters.type));
+  if (filters.lang) qs.set("lang", String(filters.lang));
+  if (filters.area) qs.set("area", String(filters.area));
+  if (filters.year) qs.set("year", String(filters.year));
+  if (filters.order) qs.set("order", String(filters.order));
+  const url = `${API_BASE}/vod?${qs.toString()}`;
+  const data = await fetchJson(url);
+  const vods = Array.isArray(data?.data?.vods) ? data.data.vods : [];
+  const totalVods = Number(data?.data?.totalVods || vods.length || 0);
+  return { url, vods, totalVods };
+}
+
+async function fetchSearchApi(keyword, page) {
+  const qs = new URLSearchParams();
+  qs.set("kw", keyword);
+  qs.set("page", String(page || 1));
+  const url = `${API_BASE}/vod/search?${qs.toString()}`;
+  const data = await fetchJson(url);
+  const vods = Array.isArray(data?.data?.vods) ? data.data.vods : [];
+  const totalVods = Number(data?.data?.totalVods || vods.length || 0);
+  return { url, vods, totalVods };
 }
 
 async function home(params, context) {
@@ -360,17 +435,35 @@ async function home(params, context) {
 
 async function category(params, context) {
   await log("info", "category 开始", { params: params || {}, from: context?.from || "web" });
+  const typeId = String(params.categoryId || params.type_id || params.type || "movie").trim();
+  const page = Math.max(1, parseInt(params.page || 1, 10));
+  const filters = params.filters || {};
   try {
-    const typeId = String(params.categoryId || params.type_id || params.type || "movie").trim();
-    const page = Math.max(1, parseInt(params.page || 1, 10));
-    const subType = String((params.filters && params.filters.type) || params.type || "").trim();
-    const path = subType ? `/video/${typeId}?type=${encodeURIComponent(subType)}` : `/video/${typeId}`;
+    const api = await fetchCategoryApi(typeId, page, filters);
+    const apiList = api.vods.map((item) => mapVodItem(item, typeId));
+    await log("info", "category API 结果", {
+      typeId,
+      page,
+      filters,
+      apiUrl: api.url,
+      listCount: apiList.length,
+      totalVods: api.totalVods,
+      first: apiList[0] || null,
+    });
+    if (apiList.length || Object.values(filters).some(Boolean)) {
+      return {
+        page,
+        pagecount: Math.max(1, Math.ceil((api.totalVods || apiList.length || 0) / 24)),
+        total: api.totalVods,
+        filters: FILTERS[typeId] || [],
+        list: apiList,
+      };
+    }
 
-    const categoryHtml = await fetchText(`${HOST}${path}`);
+    const categoryHtml = await fetchText(`${HOST}/video/${typeId}`);
     await log("info", "category 页面抓取完成", {
       typeId,
       page,
-      path,
       htmlLength: categoryHtml.length,
       rawVodNameCount: (categoryHtml.match(/vodName/g) || []).length,
       rawUrlPrefixCount: (categoryHtml.match(/urlPrefix/g) || []).length,
@@ -378,7 +471,6 @@ async function category(params, context) {
 
     let list = extractSectionList(categoryHtml, typeId);
     await log("info", "category 页面解析结果", { typeId, page, listCount: list.length, first: list[0] || null });
-
     if (!list.length) {
       const homeHtml = await fetchText(`${HOST}/`);
       await log("info", "category 回退首页抓取完成", {
@@ -400,15 +492,16 @@ async function category(params, context) {
     };
   } catch (e) {
     await log("error", "category 失败", { error: e.message, params });
-    return { page: 1, pagecount: 0, total: 0, filters: FILTERS[String(params?.categoryId || params?.type_id || params?.type || "movie").trim()] || [], list: [] };
+    return { page: 1, pagecount: 0, total: 0, filters: FILTERS[typeId] || [], list: [] };
   }
 }
 
 async function detail(params, context) {
   await log("info", "detail 开始", { params: params || {}, from: context?.from || "web" });
   try {
-    const vodId = String(params.videoId || params.vod_id || params.id || "").trim();
-    const typeId = String(params.type_id || params.type || "movie").trim();
+    const decoded = decodeVodId(String(params.videoId || params.vod_id || params.id || ""));
+    const vodId = decoded.vodId || String(params.videoId || params.vod_id || params.id || "").trim();
+    const typeId = decoded.typeId || String(params.type_id || params.type || "movie").trim() || "movie";
     if (!vodId) return { list: [] };
     const url = `${HOST}/video/${typeId}/${vodId}`;
     await log("info", "detail 请求前", { url, vodId, typeId });
@@ -420,7 +513,7 @@ async function detail(params, context) {
       vodName: vod.vod_name,
       remarks: vod.vod_remarks,
       director: vod.vod_director,
-      contentLength: (vod.vod_content || '').length,
+      contentLength: (vod.vod_content || "").length,
       sourceCount: vod.vod_play_sources.length,
       episodeCount: vod.vod_play_sources.reduce((n, s) => n + (s.episodes || []).length, 0),
     });
@@ -438,31 +531,25 @@ async function search(params, context) {
     const page = Math.max(1, parseInt(params.page || 1, 10));
     if (!keyword) return { page, pagecount: 0, total: 0, list: [] };
 
-    const html = await fetchText(`${HOST}/search?wd=${encodeURIComponent(keyword)}`);
-    const rawVodNameCount = (html.match(/vodName/g) || []).length;
-    const idx = html.indexOf(keyword);
-    await log("info", "search 请求后", {
+    const api = await fetchSearchApi(keyword, page);
+    const list = api.vods.map((item) => mapVodItem(item, pidToTypeId(item?.type?.pid || 1)));
+    await log("info", "search API 结果", {
       keyword,
       page,
-      htmlLength: html.length,
-      rawVodNameCount,
-      keywordIndex: idx,
-      keywordSnippet: idx >= 0 ? html.slice(Math.max(0, idx - 80), idx + 220) : "",
+      apiUrl: api.url,
+      listCount: list.length,
+      totalVods: api.totalVods,
+      first: list[0] || null,
     });
-
-    let list = extractSectionList(html, "movie");
-    if (!list.length) {
-      const homeHtml = await fetchText(`${HOST}/`);
-      const merged = mergeHomeSections(homeHtml);
-      list = merged.filter((item) => String(item.vod_name || '').includes(keyword)).slice(0, 24);
-      await log("info", "search 首页兜底结果", { keyword, page, mergedCount: merged.length, listCount: list.length, first: list[0] || null });
-    }
-
-    await log("info", "search 解析结果", { keyword, page, listCount: list.length, first: list[0] || null });
-    return { page, pagecount: page + (list.length >= 12 ? 1 : 0), total: list.length, list };
+    return {
+      page,
+      pagecount: Math.max(1, Math.ceil((api.totalVods || list.length || 0) / 24)),
+      total: api.totalVods,
+      list,
+    };
   } catch (e) {
     await log("error", "search 失败", { error: e.message, params });
-    return { page: 1, pagecount: 0, total: 0, filters: FILTERS[String(params?.categoryId || params?.type_id || params?.type || "movie").trim()] || [], list: [] };
+    return { page: 1, pagecount: 0, total: 0, list: [] };
   }
 }
 

--- a/影视/采集/威尔伯TV.js
+++ b/影视/采集/威尔伯TV.js
@@ -1,0 +1,242 @@
+// @name 威尔伯TV
+// @author 梦
+// @description 刮削：已接入，弹幕：未接入，嗅探：直接返回 play.modujx11.com 直链
+// @dependencies cheerio
+// @version 1.0.0
+// @downloadURL https://gh-proxy.org/https://github.com/Silent1566/OmniBox-Spider/raw/refs/heads/openclaw/影视/采集/威尔伯TV.js
+
+const OmniBox = require("omnibox_sdk");
+const runner = require("spider_runner");
+const cheerio = require("cheerio");
+
+const HOST = "https://wei2bo.com";
+const UA = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36";
+const HEADERS = {
+  "User-Agent": UA,
+  Referer: `${HOST}/`,
+  Origin: HOST,
+  Accept: "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8",
+};
+
+const CATEGORY_MAP = [
+  { type_id: "movie", type_name: "电影" },
+  { type_id: "tv", type_name: "电视剧" },
+  { type_id: "anime", type_name: "动漫" },
+  { type_id: "variety", type_name: "综艺" },
+];
+
+module.exports = { home, category, detail, search, play };
+runner.run(module.exports);
+
+function log(level, message, data) {
+  const suffix = typeof data === 'undefined' ? '' : ` | ${JSON.stringify(data)}`;
+  return OmniBox.log(level, `[威尔伯TV] ${message}${suffix}`);
+}
+
+function absUrl(url) {
+  const value = String(url || '').trim();
+  if (!value) return '';
+  if (/^https?:\/\//i.test(value)) return value;
+  if (value.startsWith('//')) return `https:${value}`;
+  if (value.startsWith('/')) return `${HOST}${value}`;
+  return `${HOST}/${value}`;
+}
+
+function clean(text) {
+  return String(text || '')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function fetchText(url, options = {}) {
+  return OmniBox.request(url, {
+    method: options.method || 'GET',
+    headers: {
+      ...HEADERS,
+      ...(options.headers || {}),
+      Referer: options.referer || `${HOST}/`,
+    },
+    timeout: options.timeout || 20000,
+    body: options.body,
+  }).then((res) => {
+    if (!res || Number(res.statusCode) < 200 || Number(res.statusCode) >= 400) {
+      throw new Error(`HTTP ${res?.statusCode || 'unknown'} @ ${url}`);
+    }
+    return String(res.body || '');
+  });
+}
+
+function extractCarouselList(html) {
+  const list = [];
+  const seen = new Set();
+  const regex = /\{"id":(\d+),"vod":\{"id":(\d+),"vodName":"([^"]+)","vodPic":"([^"]+)","vodRemarks":"([^"]*)"/g;
+  let match;
+  while ((match = regex.exec(html)) !== null) {
+    const vodId = String(match[2] || '').trim();
+    if (!vodId || seen.has(vodId)) continue;
+    seen.add(vodId);
+    list.push({
+      vod_id: vodId,
+      vod_name: clean(match[3]),
+      vod_pic: absUrl(match[4]),
+      vod_remarks: clean(match[5]),
+      vod_content: '',
+    });
+  }
+  return list;
+}
+
+function extractGridList(html, urlPrefix) {
+  const list = [];
+  const seen = new Set();
+  const pattern = /\{"id":(\d+),"vodName":"([^"]+)","vodPic":"([^"]+)","vodRemarks":"([^"]*)"/g;
+  let match;
+  while ((match = pattern.exec(html)) !== null) {
+    const vodId = String(match[1] || '').trim();
+    if (!vodId || seen.has(vodId)) continue;
+    seen.add(vodId);
+    list.push({
+      vod_id: vodId,
+      vod_name: clean(match[2]),
+      vod_pic: absUrl(match[3]),
+      vod_remarks: clean(match[4]),
+      vod_url: `${HOST}${urlPrefix}/${vodId}`,
+      vod_content: '',
+    });
+  }
+  return list;
+}
+
+function parseCategoryHtml(html) {
+  const urlPrefixMatch = html.match(/"urlPrefix":"\/(movie|tv|anime|variety)"/);
+  const urlPrefix = urlPrefixMatch ? `/${urlPrefixMatch[1]}` : '';
+  if (urlPrefix) {
+    const grid = extractGridList(html, urlPrefix);
+    if (grid.length) return grid;
+  }
+  return extractCarouselList(html);
+}
+
+function buildDetailResult(html, vodId) {
+  const $ = cheerio.load(html);
+  const title = clean($('title').text()).replace(/\s+在线观看.*$/, '') || clean($('meta[property="og:title"]').attr('content'));
+  const poster = absUrl($('meta[property="og:image"]').attr('content'));
+  const content = clean($('meta[property="og:description"]').attr('content') || $('meta[name="description"]').attr('content') || '');
+  const director = clean($('a[href*="google.com/search?q=导演:"]').text() || '');
+  const infoLine = clean($('.space-y-2 p.text-gray-1').first().text());
+  const playUrl = $('div[class*="grid-cols-[1fr_300px]"] [url]').attr('url') || '';
+  const episodes = [];
+  const epText = String($('div[class*="grid-cols-[1fr_300px]"] [episodes]').attr('episodes') || '');
+  if (epText) {
+    try {
+      const arr = JSON.parse(epText.replace(/&quot;/g, '"'));
+      for (const item of arr) {
+        const [name, url] = String(item || '').split('$');
+        if (name && url) episodes.push({ name, playId: url });
+      }
+    } catch {}
+  }
+  if (!episodes.length && playUrl) {
+    episodes.push({ name: '正片', playId: playUrl });
+  }
+  return {
+    vod_id: String(vodId || ''),
+    vod_name: title,
+    vod_pic: poster,
+    vod_content: content,
+    vod_actor: '',
+    vod_director: director || '',
+    vod_remarks: infoLine,
+    vod_play_sources: episodes.length ? [{ name: '正片', episodes }] : [],
+  };
+}
+
+async function home() {
+  try {
+    const html = await fetchText(`${HOST}/`);
+    const list = extractCarouselList(html);
+    return { class: CATEGORY_MAP, filters: {}, list };
+  } catch (e) {
+    await log('error', 'home 失败', { error: e.message });
+    return { class: CATEGORY_MAP, filters: {}, list: [] };
+  }
+}
+
+async function category(params) {
+  try {
+    const typeId = String(params.categoryId || params.type_id || params.type || 'movie');
+    const page = Math.max(1, parseInt(params.page || 1, 10));
+    const subType = String((params.filters && params.filters.type) || params.type || '').trim();
+    const path = subType ? `/video/${typeId}?type=${encodeURIComponent(subType)}` : `/video/${typeId}`;
+    const html = await fetchText(`${HOST}${path}`);
+    const list = parseCategoryHtml(html);
+    return {
+      page,
+      pagecount: page + (list.length >= 12 ? 1 : 0),
+      total: list.length,
+      list,
+    };
+  } catch (e) {
+    await log('error', 'category 失败', { error: e.message, params });
+    return { page: 1, pagecount: 0, total: 0, list: [] };
+  }
+}
+
+async function detail(params) {
+  try {
+    const vodId = String(params.videoId || params.vod_id || params.id || '').trim();
+    const typeId = String(params.type_id || params.type || 'movie').trim();
+    if (!vodId) return { list: [] };
+    const html = await fetchText(`${HOST}/video/${typeId}/${vodId}`);
+    const vod = buildDetailResult(html, vodId);
+    return { list: [vod] };
+  } catch (e) {
+    await log('error', 'detail 失败', { error: e.message, params });
+    return { list: [] };
+  }
+}
+
+async function search(params) {
+  try {
+    const keyword = String(params.keyword || params.wd || params.key || '').trim();
+    const page = Math.max(1, parseInt(params.page || 1, 10));
+    if (!keyword) return { page, pagecount: 0, total: 0, list: [] };
+    const html = await fetchText(`${HOST}/search?wd=${encodeURIComponent(keyword)}`);
+    const list = [];
+    const re = /\{"id":(\d+),"vodName":"([^"]+)","vodPic":"([^"]+)","vodRemarks":"([^"]*)"/g;
+    let match;
+    while ((match = re.exec(html)) !== null) {
+      list.push({
+        vod_id: String(match[1]),
+        vod_name: clean(match[2]),
+        vod_pic: absUrl(match[3]),
+        vod_remarks: clean(match[4]),
+      });
+    }
+    return { page, pagecount: page + (list.length >= 12 ? 1 : 0), total: list.length, list };
+  } catch (e) {
+    await log('error', 'search 失败', { error: e.message, params });
+    return { page: 1, pagecount: 0, total: 0, list: [] };
+  }
+}
+
+async function play(params) {
+  try {
+    const playUrl = String(params.playId || params.url || '').trim();
+    if (!playUrl) return { parse: 0, urls: [] };
+    return {
+      parse: 0,
+      flag: String(params.flag || '威尔伯TV'),
+      header: { Referer: HOST, Origin: HOST, 'User-Agent': UA },
+      urls: [{ name: String(params.name || '正片'), url: playUrl }],
+    };
+  } catch (e) {
+    await log('error', 'play 失败', { error: e.message, params });
+    return { parse: 0, urls: [] };
+  }
+}

--- a/影视/采集/威尔伯TV.js
+++ b/影视/采集/威尔伯TV.js
@@ -2,7 +2,7 @@
 // @author 梦
 // @description 刮削：已接入，弹幕：未接入，嗅探：直接返回 play.modujx11.com 直链
 // @dependencies cheerio
-// @version 1.0.0
+// @version 1.0.1
 // @downloadURL https://gh-proxy.org/https://github.com/Silent1566/OmniBox-Spider/raw/refs/heads/openclaw/影视/采集/威尔伯TV.js
 
 const OmniBox = require("omnibox_sdk");
@@ -129,20 +129,16 @@ function buildDetailResult(html, vodId) {
   const content = clean($('meta[property="og:description"]').attr('content') || $('meta[name="description"]').attr('content') || '');
   const director = clean($('a[href*="google.com/search?q=导演:"]').text() || '');
   const infoLine = clean($('.space-y-2 p.text-gray-1').first().text());
-  const playUrl = $('div[class*="grid-cols-[1fr_300px]"] [url]').attr('url') || '';
+  const text = decodeRsc(html);
+  const playUrlMatch = text.match(/https:\/\/play\.modujx11\.com\/[^"\s]+\.m3u8/);
+  const episodeMatch = text.match(/episodes\":\[\"([^\"]+)\"\]/);
   const episodes = [];
-  const epText = String($('div[class*="grid-cols-[1fr_300px]"] [episodes]').attr('episodes') || '');
-  if (epText) {
-    try {
-      const arr = JSON.parse(epText.replace(/&quot;/g, '"'));
-      for (const item of arr) {
-        const [name, url] = String(item || '').split('$');
-        if (name && url) episodes.push({ name, playId: url });
-      }
-    } catch {}
+  if (episodeMatch) {
+    const [name, url] = String(episodeMatch[1] || '').split('$');
+    if (name && url) episodes.push({ name, playId: url });
   }
-  if (!episodes.length && playUrl) {
-    episodes.push({ name: '正片', playId: playUrl });
+  if (!episodes.length && playUrlMatch) {
+    episodes.push({ name: '正片', playId: playUrlMatch[1] });
   }
   return {
     vod_id: String(vodId || ''),


### PR DESCRIPTION
## 变更说明
- 新增 `影视/采集/威尔伯TV.js`，接入威尔伯TV（`https://wei2bo.com/`）OmniBox 源。
- 完成首页、分类、详情、搜索、播放五个核心方法。
- 详情页补齐标题、导演、年份、类型/语言备注、简介等字段。
- 播放链路改为直接返回 `play.modujx11.com` 的 m3u8 直链。

## 重点修复
- 修复首页/分类初版无数据的问题，补充前后关键日志，便于后续定位写源问题。
- 分类与筛选不再依赖页面 HTML 猜测，改为走威尔伯TV真实后端接口：
  - `GET https://api.wei2bo.com/api/v1/vod`
- 搜索改为走真实搜索接口：
  - `GET https://api.wei2bo.com/api/v1/vod/search?kw=...&page=...`
- 修正语言、地区筛选参数映射：后端实际接受中文值（如 `韩语`、`台湾`），不是前端枚举数字 id。

## 已支持能力
- 首页推荐
- 分类列表
- 详情页
- 搜索
- 播放直链
- 分类筛选：
  - 按类型
  - 按语言
  - 按地区
  - 按年份
  - 按时间 / 按人气

## 验证
- `node --check 影视/采集/威尔伯TV.js`
- 已实测分类 API：
  - `pid + typeId + lang + area + year + order` 组合可正常请求
- 已实测搜索 API：
  - `kw=孤雁&page=1`
  - `kw=掌中刃&page=1`

## 备注
- 本次排查确认：
  - 首页源码内存在结构化数据块
  - 分类页 HTML 本身并不稳定提供同型数据
  - 真正可靠的数据源是威尔伯TV后端 API
