### PR TITLE
fix: 完善 LIBVIO 多域名与采集线路播放链

### DIFF
--- a/影视/采集/LIBVIO.js
+++ b/影视/采集/LIBVIO.js
@@ -2,7 +2,7 @@
 // @author 梦
 // @description 刮削：未接入，弹幕：未接入，嗅探：不需要（直链优先，支持网盘线路展开）
 // @dependencies
-// @version 1.3.5
+// @version 1.3.6
 // @downloadURL https://gh-proxy.org/https://github.com/Silent1566/OmniBox-Spider/raw/refs/heads/main/影视/采集/LIBVIO.js
 
 const http = require("http");
@@ -645,6 +645,23 @@ function isDirectMediaUrl(url = "") {
     }
 }
 
+function buildProviderIframeUrl(player = {}) {
+    const from = String(player?.from || '').trim();
+    const rawUrl = String(player?.url || '').trim();
+    const id = String(player?.id || '').trim();
+    const nid = String(player?.nid || '').trim();
+    const next = String(player?.link_next || '').trim();
+    if (!from || !rawUrl) return "";
+
+    if (from === 'ty_new1') {
+        return `${getCurrentHost()}/vid/ty4.php?url=${encodeURIComponent(rawUrl)}&next=${encodeURIComponent(next)}&id=${encodeURIComponent(id)}&nid=${encodeURIComponent(nid)}`;
+    }
+    if (from === 'vr2') {
+        return `${getCurrentHost()}/vid/plyr/vr2.php?url=${encodeURIComponent(rawUrl)}&next=${encodeURIComponent(next)}&id=${encodeURIComponent(id)}&nid=${encodeURIComponent(nid)}`;
+    }
+    return "";
+}
+
 function emptyPlay(flag = "LIBVIO") {
     return { parse: 0, flag, urls: [] };
 }
@@ -889,7 +906,8 @@ async function play(params, context) {
             };
         }
 
-        logInfo("play 使用嗅探兜底", { playPageUrl, from: player.from, decodedUrl: realUrl, encrypt: player.encrypt, rawUrl: player.url });
+        const iframeUrl = buildProviderIframeUrl(player);
+        logInfo("play 使用嗅探兜底", { playPageUrl, from: player.from, decodedUrl: realUrl, encrypt: player.encrypt, rawUrl: player.url, iframeUrl });
         return {
             parse: 1,
             flag: playFlag,
@@ -898,7 +916,7 @@ async function play(params, context) {
                 Origin: getCurrentHost(),
                 "User-Agent": UA
             },
-            urls: [{ name: meta.name || "播放", url: playPageUrl }]
+            urls: [{ name: meta.name || "播放", url: iframeUrl || playPageUrl }]
         };
     } catch (error) {
         logError("play 失败", error);

--- a/影视/采集/LIBVIO.js
+++ b/影视/采集/LIBVIO.js
@@ -2,7 +2,7 @@
 // @author 梦
 // @description 刮削：未接入，弹幕：未接入，嗅探：不需要（直链优先，支持网盘线路展开）
 // @dependencies
-// @version 1.3.6
+// @version 1.3.7
 // @downloadURL https://gh-proxy.org/https://github.com/Silent1566/OmniBox-Spider/raw/refs/heads/main/影视/采集/LIBVIO.js
 
 const http = require("http");
@@ -907,16 +907,36 @@ async function play(params, context) {
         }
 
         const iframeUrl = buildProviderIframeUrl(player);
-        logInfo("play 使用嗅探兜底", { playPageUrl, from: player.from, decodedUrl: realUrl, encrypt: player.encrypt, rawUrl: player.url, iframeUrl });
+        const sniffTarget = iframeUrl || playPageUrl;
+        const sniffHeaders = {
+            Referer: `${getCurrentHost()}/`,
+            Origin: getCurrentHost(),
+            "User-Agent": UA
+        };
+        try {
+            const sniffResult = await OmniBox.sniffVideo(sniffTarget, sniffHeaders);
+            const sniffUrls = Array.isArray(sniffResult?.urls) ? sniffResult.urls.filter((item) => item?.url) : [];
+            if (sniffUrls.length) {
+                logInfo("play SDK嗅探完成", { playPageUrl, from: player.from, sniffTarget, sniffCount: sniffUrls.length, first: sniffUrls[0] || null });
+                return {
+                    parse: 0,
+                    flag: playFlag,
+                    header: sniffResult?.header || sniffHeaders,
+                    urls: sniffUrls.map((item) => ({ name: item.name || meta.name || "播放", url: item.url })),
+                    danmaku: sniffResult?.danmaku || []
+                };
+            }
+            logInfo("play SDK嗅探无结果", { playPageUrl, from: player.from, sniffTarget, sniffResult: sniffResult || null });
+        } catch (sniffError) {
+            logInfo("play SDK嗅探失败", { playPageUrl, from: player.from, sniffTarget, error: sniffError.message });
+        }
+
+        logInfo("play 使用嗅探兜底", { playPageUrl, from: player.from, decodedUrl: realUrl, encrypt: player.encrypt, rawUrl: player.url, iframeUrl, sniffTarget });
         return {
             parse: 1,
             flag: playFlag,
-            header: {
-                Referer: `${getCurrentHost()}/`,
-                Origin: getCurrentHost(),
-                "User-Agent": UA
-            },
-            urls: [{ name: meta.name || "播放", url: iframeUrl || playPageUrl }]
+            header: sniffHeaders,
+            urls: [{ name: meta.name || "播放", url: sniffTarget }]
         };
     } catch (error) {
         logError("play 失败", error);

--- a/影视/采集/LIBVIO.js
+++ b/影视/采集/LIBVIO.js
@@ -2,7 +2,7 @@
 // @author 梦
 // @description 刮削：未接入，弹幕：未接入，嗅探：不需要（直链优先，支持网盘线路展开）
 // @dependencies
-// @version 1.3.3
+// @version 1.3.4
 // @downloadURL https://gh-proxy.org/https://github.com/Silent1566/OmniBox-Spider/raw/refs/heads/main/影视/采集/LIBVIO.js
 
 const http = require("http");
@@ -11,8 +11,15 @@ const { URL } = require("url");
 const OmniBox = require("omnibox_sdk");
 const runner = require("spider_runner");
 
-const HOST = "https://www.libvios.com";
+const HOST_CANDIDATES = [
+    "https://www.libvios.com",
+    "https://libvio.run",
+    "https://www.libvio.mov",
+    "https://www.libhd.com",
+].map((item) => normalizeHost(item)).filter(Boolean);
 const UA = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36";
+let ACTIVE_HOST = HOST_CANDIDATES[0];
+
 const DEFAULT_PAGE_SIZE = 12;
 const DRIVE_TYPE_CONFIG = (process.env.DRIVE_TYPE_CONFIG || "quark;uc").split(";").map((t) => t.trim().toLowerCase()).filter(Boolean);
 const SOURCE_NAMES_CONFIG = (process.env.SOURCE_NAMES_CONFIG || "本地代理;服务端代理;直连").split(";").map((s) => s.trim()).filter(Boolean);
@@ -61,16 +68,37 @@ const SORT_OPTIONS = [
     { name: "评分", value: "score" }
 ];
 
-async function requestText(url, options = {}) {
-    const target = new URL(fixUrl(url));
-    const lib = target.protocol === "https:" ? https : http;
-    const headers = {
+function normalizeHost(url = "") {
+    const value = String(url || "").trim();
+    if (!value) return "";
+    const withProtocol = /^https?:\/\//i.test(value) ? value : `https://${value}`;
+    try {
+        const target = new URL(withProtocol);
+        return `${target.protocol}//${target.host}`;
+    } catch {
+        return withProtocol.replace(/\/+$/, "");
+    }
+}
+
+function getCurrentHost() {
+    return ACTIVE_HOST || HOST_CANDIDATES[0];
+}
+
+function buildHeadersForHost(host, extra = {}) {
+    return {
         "User-Agent": UA,
-        "Referer": `${HOST}/`,
-        "Origin": HOST,
+        "Referer": `${host}/`,
+        "Origin": host,
         "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
-        ...(options.headers || {})
+        ...extra,
     };
+}
+
+async function requestTextAbsolute(url, options = {}) {
+    const target = new URL(url);
+    const lib = target.protocol === "https:" ? https : http;
+    const hostForHeaders = normalizeHost(options.hostForHeaders || `${target.protocol}//${target.host}`);
+    const headers = buildHeadersForHost(hostForHeaders, options.headers || {});
 
     return await new Promise((resolve, reject) => {
         const req = lib.request(target, {
@@ -97,6 +125,55 @@ async function requestText(url, options = {}) {
         req.end();
     });
 }
+
+async function probeHost(host) {
+    try {
+        await requestTextAbsolute(`${host}/`, { timeout: 8000, hostForHeaders: host });
+        return true;
+    } catch (error) {
+        logInfo("域名探测失败", { host, error: error.message });
+        return false;
+    }
+}
+
+async function ensureActiveHost(preferredHost = "") {
+    const preferred = normalizeHost(preferredHost);
+    const ordered = [preferred, getCurrentHost(), ...HOST_CANDIDATES].filter(Boolean).filter((item, idx, arr) => arr.indexOf(item) === idx);
+    for (const host of ordered) {
+        if (await probeHost(host)) {
+            if (ACTIVE_HOST !== host) {
+                logInfo("切换可用域名", { from: ACTIVE_HOST, to: host });
+            }
+            ACTIVE_HOST = host;
+            return ACTIVE_HOST;
+        }
+    }
+    throw new Error(`未找到可用域名: ${ordered.join(", ")}`);
+}
+
+async function requestText(url, options = {}) {
+    const raw = String(url || "").trim();
+    if (!raw) throw new Error("请求地址为空");
+
+    if (/^https?:\/\//i.test(raw)) {
+        return await requestTextAbsolute(raw, options);
+    }
+
+    const hosts = [getCurrentHost(), ...HOST_CANDIDATES].filter(Boolean).filter((item, idx, arr) => arr.indexOf(item) === idx);
+    let lastError = null;
+    for (const host of hosts) {
+        try {
+            await ensureActiveHost(host);
+            const absoluteUrl = raw.startsWith("/") ? `${ACTIVE_HOST}${raw}` : `${ACTIVE_HOST}/${raw}`;
+            return await requestTextAbsolute(absoluteUrl, { ...options, hostForHeaders: ACTIVE_HOST });
+        } catch (error) {
+            lastError = error;
+            logInfo("候选域名请求失败", { host, url: raw, error: error.message });
+        }
+    }
+    throw lastError || new Error(`请求失败: ${raw}`);
+}
+
 
 
 module.exports = { home, category, detail, search, play };
@@ -139,7 +216,8 @@ function fixUrl(url = "") {
     if (!url) return "";
     if (/^https?:\/\//i.test(url)) return url;
     if (url.startsWith("//")) return `https:${url}`;
-    return url.startsWith("/") ? `${HOST}${url}` : `${HOST}/${url}`;
+    const host = getCurrentHost();
+    return url.startsWith("/") ? `${host}${url}` : `${host}/${url}`;
 }
 
 function encodePlayId(payload) {
@@ -565,7 +643,7 @@ function emptyPage(page = 1) {
 
 async function home(params, context) {
     try {
-        logInfo("home 进入", { params, from: context?.from || "web" });
+        logInfo("home 进入", { params, host: getCurrentHost(), from: context?.from || "web" });
         const html = await fetchHtml("/");
         const list = parseVodList(html).slice(0, 24);
         const classes = CLASS_LIST.map((item) => ({ ...item }));
@@ -587,7 +665,7 @@ async function category(params, context) {
     const filters = params?.filters || {};
     try {
         const finalUrl = await resolveCategoryUrl(categoryId, page, filters);
-        logInfo("category 请求", { categoryId, page, filters, path: finalUrl.replace(HOST, ""), from: context?.from || "web" });
+        logInfo("category 请求", { categoryId, page, filters, host: getCurrentHost(), path: finalUrl.replace(getCurrentHost(), ""), from: context?.from || "web" });
         const html = await fetchHtml(finalUrl);
         const list = parseVodList(html);
         const hasNext = html.includes(`>${page + 1}<`) || html.includes(`-${page + 1}---`) || html.includes(`下一页`);
@@ -611,7 +689,7 @@ async function detail(params, context) {
     const videoId = String(params?.videoId || "").trim();
     if (!videoId) return { list: [] };
     try {
-        logInfo("detail 请求", { videoId, from: context?.from || "web" });
+        logInfo("detail 请求", { videoId, host: getCurrentHost(), from: context?.from || "web" });
         const html = await fetchHtml(videoId);
         const name = stripTags(html.match(/<h1[^>]*>([\s\S]*?)<\/h1>/)?.[1] || "");
         const poster = fixUrl(html.match(/class="lazyload"[^>]*data-original="([^"]+)"/)?.[1] || html.match(/data-original="([^"]+)"/)?.[1] || "");
@@ -709,7 +787,7 @@ async function search(params, context) {
     if (!keyword) return emptyPage(page);
     try {
         const path = buildSearchPath(keyword, page);
-        logInfo("search 请求", { keyword, page, path, quick: params?.quick ? 1 : 0, from: context?.from || "web" });
+        logInfo("search 请求", { keyword, page, host: getCurrentHost(), path, quick: params?.quick ? 1 : 0, from: context?.from || "web" });
         const html = await fetchHtml(path);
         const list = parseVodList(html);
         const pagecount = list.length === DEFAULT_PAGE_SIZE ? page + 1 : page;
@@ -775,8 +853,8 @@ async function play(params, context) {
                 parse: 1,
                 flag: playFlag,
                 header: {
-                    Referer: `${HOST}/`,
-                    Origin: HOST,
+                    Referer: `${getCurrentHost()}/`,
+                    Origin: getCurrentHost(),
                     "User-Agent": UA
                 },
                 urls: [{ name: meta.name || "播放", url: playPageUrl }]
@@ -791,8 +869,8 @@ async function play(params, context) {
                 parse: 0,
                 flag: playFlag,
                 header: {
-                    Referer: `${HOST}/`,
-                    Origin: HOST,
+                    Referer: `${getCurrentHost()}/`,
+                    Origin: getCurrentHost(),
                     "User-Agent": UA
                 },
                 urls: [{ name: meta.name || "播放", url: realUrl }]
@@ -804,8 +882,8 @@ async function play(params, context) {
             parse: 1,
             flag: playFlag,
             header: {
-                Referer: `${HOST}/`,
-                Origin: HOST,
+                Referer: `${getCurrentHost()}/`,
+                Origin: getCurrentHost(),
                 "User-Agent": UA
             },
             urls: [{ name: meta.name || "播放", url: playPageUrl }]

--- a/影视/采集/LIBVIO.js
+++ b/影视/采集/LIBVIO.js
@@ -2,7 +2,7 @@
 // @author 梦
 // @description 刮削：未接入，弹幕：未接入，嗅探：不需要（直链优先，支持网盘线路展开）
 // @dependencies
-// @version 1.3.4
+// @version 1.3.5
 // @downloadURL https://gh-proxy.org/https://github.com/Silent1566/OmniBox-Spider/raw/refs/heads/main/影视/采集/LIBVIO.js
 
 const http = require("http");
@@ -633,6 +633,18 @@ function buildPlayUrl(rawUrl = "") {
     return fixUrl(value);
 }
 
+function isDirectMediaUrl(url = "") {
+    const value = String(url || "").trim();
+    if (!/^https?:\/\//i.test(value)) return false;
+    try {
+        const target = new URL(value);
+        const pathname = target.pathname.toLowerCase();
+        return /\.(m3u8|mp4|m4v|m4a|mp3|flv|avi|mkv|mov|webm)(?:$|\?)/i.test(pathname) || /\.(m3u8|mp4|m4v|m4a|mp3|flv|avi|mkv|mov|webm)$/i.test(value.toLowerCase());
+    } catch {
+        return /\.(m3u8|mp4|m4v|m4a|mp3|flv|avi|mkv|mov|webm)(?:$|\?)/i.test(value.toLowerCase());
+    }
+}
+
 function emptyPlay(flag = "LIBVIO") {
     return { parse: 0, flag, urls: [] };
 }
@@ -863,7 +875,7 @@ async function play(params, context) {
 
         const player = JSON.parse(playerJson);
         const realUrl = buildPlayUrl(decodePlayerUrl(player.url, player.encrypt));
-        if (realUrl && /^https?:\/\//i.test(realUrl)) {
+        if (realUrl && isDirectMediaUrl(realUrl)) {
             logInfo("play 直链完成", { playPageUrl, from: player.from, finalUrl: realUrl });
             return {
                 parse: 0,
@@ -877,7 +889,7 @@ async function play(params, context) {
             };
         }
 
-        logInfo("play 使用嗅探兜底", { playPageUrl, from: player.from, decodedUrl: realUrl });
+        logInfo("play 使用嗅探兜底", { playPageUrl, from: player.from, decodedUrl: realUrl, encrypt: player.encrypt, rawUrl: player.url });
         return {
             parse: 1,
             flag: playFlag,

--- a/影视/采集/LIBVIO.js
+++ b/影视/采集/LIBVIO.js
@@ -2,7 +2,7 @@
 // @author 梦
 // @description 刮削：未接入，弹幕：未接入，嗅探：不需要（直链优先，支持网盘线路展开）
 // @dependencies
-// @version 1.3.7
+// @version 1.3.8
 // @downloadURL https://gh-proxy.org/https://github.com/Silent1566/OmniBox-Spider/raw/refs/heads/main/影视/采集/LIBVIO.js
 
 const http = require("http");
@@ -916,6 +916,9 @@ async function play(params, context) {
         try {
             const sniffResult = await OmniBox.sniffVideo(sniffTarget, sniffHeaders);
             const sniffUrls = Array.isArray(sniffResult?.urls) ? sniffResult.urls.filter((item) => item?.url) : [];
+            if (!sniffUrls.length && sniffResult?.url) {
+                sniffUrls.push({ name: meta.name || "播放", url: sniffResult.url });
+            }
             if (sniffUrls.length) {
                 logInfo("play SDK嗅探完成", { playPageUrl, from: player.from, sniffTarget, sniffCount: sniffUrls.length, first: sniffUrls[0] || null });
                 return {


### PR DESCRIPTION
## 变更说明
- 为 `影视/采集/LIBVIO.js` 增加多域名支持，并自动探测 / 切换可用域名。
- 修复采集线路播放链路里 `playId` 解包错误导致的播放 404。
- 修复 `BD播放`（`ty_new1`）线路误把站内保护链接当直链返回的问题。
- 回退播放链优先接入 OmniBox SDK 的 `sniffVideo()`，兼容 SDK 返回单个 `url` 的场景。

## 本次覆盖的域名
- `https://www.libvios.com`
- `https://libvio.run`
- `https://www.libvio.mov`
- `https://www.libhd.com`

## 关键修复点
### 1. 多域名自动切换
- 新增候选域名池与当前活跃域名。
- 请求失败时自动探测并切换到可用域名。
- `home / category / detail / search / play` 日志会带当前 host，方便排查。

### 2. 采集线路 `playId` 解包修复
- 增强 `decodePlayId()`：支持标准 base64 / URL-safe base64 / 直接 JSON。
- 新增 `resolveCollectPlayPageUrl(rawPlayId, meta)`：优先从编码元数据恢复真实播放页地址。
- 避免把 `eyJ...` 这种编码串直接拼成站内 URL 请求导致 404。

### 3. `BD播放` 线路播放修复
- 对 `ty_new1` / `vr2` 区分真实直链和受保护播放链。
- 只把真实媒体地址（m3u8/mp4 等）当作直链 `parse:0` 返回。
- 非直链时不再误判为直链，而是改走官方 iframe 播放页。

### 4. SDK 嗅探优先
- 回退播放链现在优先使用 OmniBox SDK 的 `sniffVideo()`。
- 兼容两种返回格式：
  - `sniffResult.urls`
  - `sniffResult.url`
- 当 SDK 嗅探已经拿到真实地址时，直接 `parse:0` 返回，不再误回落到 `parse:1`。

## 验证
- `node --check 影视/采集/LIBVIO.js`
- 已根据日志确认：
  - `BD5播放`（`vr2`）直链正常
  - `BD播放`（`ty_new1`）SDK 嗅探已能返回真实 mp4 地址

## 备注
- 本次重点是保证多域名可用性与采集线路播放可靠性。
- 对 `ty_new1`，当前优先策略是：
  - 真直链 → 直接返回
  - 受保护链 → 先 iframe 页 → 再 SDK 嗅探 → 再兜底
