### PR TITLE
fix: 修正聚盘搜索接口域名迁移

### DIFF
--- a/影视/网盘/聚盘搜索.js
+++ b/影视/网盘/聚盘搜索.js
@@ -10,7 +10,8 @@ const axios = require("axios");
 const OmniBox = require("omnibox_sdk");
 const runner = require("spider_runner");
 
-const BASE = "https://pan.dyuzi.com";
+// 站点基地址（旧域 pan.dyuzi.com 已迁移/跳转到 ppan.dyuzi.com）
+const BASE = "https://ppan.dyuzi.com";
 const API = `${BASE}/api/frontend`;
 const UA = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/123.0.0.0 Safari/537.36";
 

--- a/影视/网盘/聚盘搜索分组.js
+++ b/影视/网盘/聚盘搜索分组.js
@@ -11,8 +11,8 @@ const OmniBox = require("omnibox_sdk");
 const runner = require("spider_runner");
 
 // ==================== 配置区域开始 ====================
-// 站点基地址
-const BASE = "https://pan.dyuzi.com";
+// 站点基地址（旧域 pan.dyuzi.com 已迁移/跳转到 ppan.dyuzi.com）
+const BASE = "https://ppan.dyuzi.com";
 // 站点前端 API 根地址
 const API = `${BASE}/api/frontend`;
 // 默认请求 User-Agent


### PR DESCRIPTION
## 变更说明
- 将 `影视/网盘/聚盘搜索.js` 切换到 `ppan.dyuzi.com`
- 将 `影视/网盘/聚盘搜索分组.js` 切换到 `ppan.dyuzi.com`
- 修复旧域 `pan.dyuzi.com` 301 跳首页后，脚本把 HTML 当接口响应导致的首页、分类、搜索空结果问题

## 已做校验
- `node --check 影视/网盘/聚盘搜索.js`
- `node --check 影视/网盘/聚盘搜索分组.js`
- 实测 `https://ppan.dyuzi.com/api/frontend/home` / `ranking` / `search` / `searchPoll` 均能正常返回 JSON
- 实测旧域 `https://pan.dyuzi.com/api/frontend/...` 已 301 跳转，不再适合作为脚本接口基址

## 说明
- 这次先做最小修复，优先恢复首页 / 分类 / 搜索链路
- 若后续仍有分组页行为异常，再继续围绕分组模式本身排查
