### PR TITLE
chore: 补齐聚盘搜索版本号

### DIFF
--- a/影视/网盘/聚盘搜索.js
+++ b/影视/网盘/聚盘搜索.js
@@ -2,7 +2,7 @@
 // @author 梦
 // @description 站点搜索 + 网盘资源解析（夸克/百度/迅雷等），支持网盘目录展开、刮削、弹幕、观看记录
 // @dependencies: axios
-// @version 1.2.3
+// @version 1.2.4
 // @downloadURL https://gh-proxy.org/https://github.com/Silent1566/OmniBox-Spider/raw/refs/heads/main/影视/网盘/聚盘搜索.js
 
 

--- a/影视/网盘/聚盘搜索分组.js
+++ b/影视/网盘/聚盘搜索分组.js
@@ -2,7 +2,7 @@
 // @author 梦
 // @description 聚盘搜索分组版：搜索先按网盘分组，再进入二级结果；详情与播放沿用聚盘搜索的多层级展开、刮削、弹幕、观看记录能力
 // @dependencies: axios
-// @version 1.0.0
+// @version 1.0.1
 // @downloadURL https://gh-proxy.org/https://github.com/Silent1566/OmniBox-Spider/raw/refs/heads/main/影视/网盘/聚盘搜索分组.js
 
 


### PR DESCRIPTION
## 变更说明
- 将 `影视/网盘/聚盘搜索.js` 的版本号更新为 `1.2.4`
- 将 `影视/网盘/聚盘搜索分组.js` 的版本号更新为 `1.0.1`

## 背景
- 上一个修复 PR 已处理接口域名迁移问题，但遗漏了脚本头部版本号同步
- 本 PR 仅补版本号，不引入额外逻辑变更

## 已做校验
- `node --check 影视/网盘/聚盘搜索.js`
- `node --check 影视/网盘/聚盘搜索分组.js`
