### PR TITLE
chore: 完善 FlareSolverr 配置注释

### DIFF
--- a/影视/网盘/人人电影.py
+++ b/影视/网盘/人人电影.py
@@ -24,6 +24,7 @@ BASE_URL = "https://www.rrdynb.com"
 UA = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/135.0.0.0 Safari/537.36"
 
 # FlareSolverr 服务地址。留空表示不启用，需通过环境变量显式配置。
+# 项目地址：https://github.com/FlareSolverr/FlareSolverr
 RRDYNB_FLARESOLVERR_URL = str(os.environ.get("RRDYNB_FLARESOLVERR_URL") or "").strip()
 # FlareSolverr 会话名。用于复用已过验证的浏览器会话。
 RRDYNB_FLARESOLVERR_SESSION = str(os.environ.get("RRDYNB_FLARESOLVERR_SESSION") or "rrdynb-search").strip()

--- a/影视/采集/PPnix.js
+++ b/影视/采集/PPnix.js
@@ -36,8 +36,12 @@ const PPNIX_CF_AUTO = process.env.PPNIX_CF_AUTO !== "0";
 const PPNIX_CF_CACHE_KEY = process.env.PPNIX_CF_CACHE_KEY || "ppnix:cf_clearance";
 const PPNIX_CF_MAX_AGE_SECONDS = parseInt(process.env.PPNIX_CF_MAX_AGE_SECONDS || "21600", 10) || 21600;
 const PPNIX_CF_TIMEOUT_MS = parseInt(process.env.PPNIX_CF_TIMEOUT_MS || "45000", 10) || 45000;
+// FlareSolverr 服务地址，优先读取站点专用变量，其次回退通用 FLARESOLVERR_URL。
+// 项目地址：https://github.com/FlareSolverr/FlareSolverr
 const PPNIX_FLARESOLVERR_URL = process.env.PPNIX_FLARESOLVERR_URL || process.env.FLARESOLVERR_URL || "http://192.168.50.50:8191/v1";
+// FlareSolverr 会话名，用于复用已过验证的浏览器会话。
 const PPNIX_FLARESOLVERR_SESSION = process.env.PPNIX_FLARESOLVERR_SESSION || "";
+// FlareSolverr 单次请求最大等待时间（毫秒），默认沿用 CF 自动处理超时配置。
 const PPNIX_FLARESOLVERR_TIMEOUT_MS = parseInt(process.env.PPNIX_FLARESOLVERR_TIMEOUT_MS || String(PPNIX_CF_TIMEOUT_MS), 10) || PPNIX_CF_TIMEOUT_MS;
 const PPNIX_ENABLE_SUBTITLES = process.env.PPNIX_ENABLE_SUBTITLES === "1";
 const execFileAsync = promisify(execFile);

--- a/影视/采集/唐人街影院.js
+++ b/影视/采集/唐人街影院.js
@@ -19,7 +19,10 @@ const TRVOD_CF_AUTO = process.env.TRVOD_CF_AUTO !== '0';
 const TRVOD_CF_CACHE_KEY = process.env.TRVOD_CF_CACHE_KEY || 'trvod:cf_clearance';
 const TRVOD_CF_MAX_AGE_SECONDS = parseInt(process.env.TRVOD_CF_MAX_AGE_SECONDS || '21600', 10) || 21600;
 const TRVOD_CF_TIMEOUT_MS = parseInt(process.env.TRVOD_CF_TIMEOUT_MS || '60000', 10) || 60000;
+// FlareSolverr 服务地址，优先读取站点专用变量，其次回退通用 FLARESOLVERR_URL。
+// 项目地址：https://github.com/FlareSolverr/FlareSolverr
 const TRVOD_FLARESOLVERR_URL = process.env.TRVOD_FLARESOLVERR_URL || process.env.FLARESOLVERR_URL || 'http://192.168.50.50:8191/v1';
+// FlareSolverr 会话名，用于复用已过验证的浏览器会话。
 const TRVOD_FLARESOLVERR_SESSION = process.env.TRVOD_FLARESOLVERR_SESSION || '';
 
 const axiosInstance = axios.create({


### PR DESCRIPTION
## 概要
- 完善 openclaw 分支内含 `FLARESOLVERR_URL` 配置的爬虫源注释
- 为相关配置补充 FlareSolverr 项目地址
- 补充部分相关配置说明，便于后续维护

## 涉及文件
- `影视/采集/PPnix.js`
- `影视/采集/唐人街影院.js`
- `影视/网盘/人人电影.py`

## 说明
- 本次仅补充注释，不改动实际业务逻辑
- 已完成基础语法校验：`python3 -m py_compile` / `node --check`
