### PR TITLE
feat: 补齐网盘源刮削弹幕与播放记录能力

### DIFF
--- a/影视/网盘/4K指南.js
+++ b/影视/网盘/4K指南.js
@@ -1,7 +1,7 @@
 // @name 4K指南
 // @author 梦
-// @description 网盘资源站：https://4kzn.com ，支持首页、分类、详情、搜索与网盘播放
-// @version 1.1.1
+// @description 网盘资源站：https://4kzn.com ，支持首页、分类、详情、搜索、网盘播放、刮削、弹幕、播放记录
+// @version 1.2.1
 // @downloadURL https://gh-proxy.org/https://github.com/Silent1566/OmniBox-Spider/raw/refs/heads/main/影视/网盘/4K指南.js
 // @dependencies cheerio
 
@@ -77,6 +77,77 @@ function formatFileSize(size) {
   if (n < 1024 ** 3) return `${(n / 1024 ** 2).toFixed(2)}MB`;
   if (n < 1024 ** 4) return `${(n / 1024 ** 3).toFixed(2)}GB`;
   return `${(n / 1024 ** 4).toFixed(2)}TB`;
+}
+
+function encodePlayMeta(meta) {
+  try {
+    return Buffer.from(JSON.stringify(meta || {}), "utf8").toString("base64");
+  } catch (_) {
+    return "";
+  }
+}
+
+function decodePlayMeta(meta) {
+  try {
+    return JSON.parse(Buffer.from(String(meta || ""), "base64").toString("utf8") || "{}");
+  } catch (_) {
+    return {};
+  }
+}
+
+function buildScrapedFileName(scrapeData, mapping, originalFileName) {
+  if (!mapping || mapping.episodeNumber === 0 || (mapping.confidence && mapping.confidence < 0.5)) {
+    return originalFileName;
+  }
+
+  if (!scrapeData || !scrapeData.title) {
+    return originalFileName;
+  }
+
+  if (scrapeData.type === "tv" || mapping.seasonNumber) {
+    const seasonNum = mapping.seasonNumber || 1;
+    const epNum = mapping.episodeNumber || 1;
+    const seasonAirYear = scrapeData.seasonAirYear || "";
+    let name = `${scrapeData.title}`;
+    if (seasonAirYear) name += `.${seasonAirYear}`;
+    name += `.S${String(seasonNum).padStart(2, "0")}E${String(epNum).padStart(2, "0")}`;
+    return name;
+  }
+
+  return scrapeData.title || originalFileName;
+}
+
+function normalizeEpisodeName(episodeName) {
+  if (!episodeName) return "";
+  return String(episodeName)
+    .replace(/\[[^\]]*\]/g, " ")
+    .replace(/\([^)]*\)/g, " ")
+    .replace(/（[^）]*）/g, " ")
+    .replace(/第\s*([0-9一二三四五六七八九十百千零〇两]+)\s*[集话期]/g, "E$1")
+    .replace(/[._-]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function buildFileNameForDanmu(vodName, episodeTitle) {
+  const title = cleanText(vodName || "");
+  const episode = normalizeEpisodeName(episodeTitle || "");
+  if (!title) return episode;
+  if (!episode || title.includes(episode)) return title;
+  return `${title} ${episode}`;
+}
+
+function buildPlayHistoryPayload({ sourceId, vodId, title, pic, episode, episodeName, episodeNumber }) {
+  if (!sourceId || !vodId) return null;
+  return {
+    vodId,
+    title: title || "",
+    pic: pic || "",
+    episode,
+    sourceId,
+    episodeNumber: typeof episodeNumber === "number" ? episodeNumber : undefined,
+    episodeName: episodeName || "",
+  };
 }
 
 function getBaseURLHost(context = {}) {
@@ -376,6 +447,7 @@ async function detail(params, context) {
     }
 
     const driveTypeCurrentIndexMap = {};
+    const filesForScraping = [];
     let playSources = [];
 
     for (const item of rawDriveInfos) {
@@ -399,10 +471,25 @@ async function detail(params, context) {
 
       const episodes = dedupeEpisodes(allVideoFiles.map((file) => {
         const sizeText = formatFileSize(file.size);
+        const episodeName = cleanText(String(file.file_name || "资源").replace(/\.[^.]+$/, "")) || "资源";
         const displayFileName = sizeText ? `[${sizeText}] ${file.file_name}` : file.file_name;
+        const playMeta = encodePlayMeta({
+          sid: detailUrl,
+          t: title,
+          p: pic,
+          e: episodeName,
+        });
+        const formattedFileId = `${shareURL}|${file.fid}`;
+        if (file.fid && !filesForScraping.some((item) => item.fid === formattedFileId)) {
+          filesForScraping.push({
+            file_name: episodeName,
+            fid: formattedFileId,
+            file_id: formattedFileId,
+          });
+        }
         return {
           name: displayFileName,
-          playId: `${shareURL}|${file.fid}`,
+          playId: playMeta ? `${shareURL}|${file.fid}|${playMeta}` : `${shareURL}|${file.fid}`,
         };
       }));
 
@@ -432,18 +519,61 @@ async function detail(params, context) {
       playSources = sortPlaySourcesByDriveOrder(playSources);
     }
 
-    await OmniBox.log("info", `[4K指南][detail] url=${detailUrl} title=${title} shareLinks=${shareLinks.length} lines=${playSources.length}`);
+    const vodItem = {
+      vod_id: detailUrl,
+      vod_name: title,
+      vod_pic: pic,
+      vod_content: desc,
+      vod_play_sources: playSources.length
+        ? playSources
+        : [{ name: "详情页", episodes: [{ name: "打开详情页", playId: `page|||${encodeURIComponent(detailUrl)}` }] }],
+    };
+
+    if (filesForScraping.length > 0) {
+      try {
+        await OmniBox.log("info", `[4K指南][detail] 开始统一刮削: vodId=${detailUrl}, files=${filesForScraping.length}`);
+        await OmniBox.processScraping(detailUrl, title || "", title || "", filesForScraping);
+        const metadata = await OmniBox.getScrapeMetadata(detailUrl);
+        const scrapeData = metadata?.scrapeData || null;
+        const videoMappings = Array.isArray(metadata?.videoMappings) ? metadata.videoMappings : [];
+
+        if (scrapeData || videoMappings.length > 0) {
+          for (const source of vodItem.vod_play_sources || []) {
+            for (const episode of source.episodes || []) {
+              const playIdParts = String(episode.playId || "").split("|");
+              const formattedId = `${String(playIdParts[0] || "")}|${String(playIdParts[1] || "")}`;
+              const matchedMapping = videoMappings.find((mapping) => mapping && mapping.fileId === formattedId);
+              if (matchedMapping && scrapeData) {
+                const newName = buildScrapedFileName(scrapeData, matchedMapping, String(episode.name || ""));
+                if (newName && newName !== episode.name) {
+                  episode.name = newName;
+                }
+              }
+            }
+          }
+
+          if (scrapeData) {
+            if (scrapeData.title) vodItem.vod_name = scrapeData.title;
+            if (scrapeData.posterPath) vodItem.vod_pic = `https://image.tmdb.org/t/p/w500${scrapeData.posterPath}`;
+            if (scrapeData.overview) vodItem.vod_content = scrapeData.overview;
+            if (scrapeData.releaseDate) vodItem.vod_year = String(scrapeData.releaseDate).slice(0, 4);
+            if (scrapeData.voteAverage) vodItem.vod_douban_score = Number(scrapeData.voteAverage).toFixed(1);
+          }
+          await OmniBox.log("info", `[4K指南][detail] 统一刮削完成: vodId=${detailUrl}, mappings=${videoMappings.length}, title=${vodItem.vod_name || title}`);
+        } else {
+          await OmniBox.log("info", `[4K指南][detail] 统一刮削无结果: vodId=${detailUrl}`);
+        }
+      } catch (error) {
+        await OmniBox.log("warn", `[4K指南][detail] 统一刮削失败: ${error.message}`);
+      }
+    } else {
+      await OmniBox.log("info", `[4K指南][detail] 跳过统一刮削: 未收集到可刮削文件`);
+    }
+
+    await OmniBox.log("info", `[4K指南][detail] url=${detailUrl} title=${vodItem.vod_name || title} shareLinks=${shareLinks.length} lines=${playSources.length}`);
 
     return {
-      list: [{
-        vod_id: detailUrl,
-        vod_name: title,
-        vod_pic: pic,
-        vod_content: desc,
-        vod_play_sources: playSources.length
-          ? playSources
-          : [{ name: "详情页", episodes: [{ name: "打开详情页", playId: `page|||${encodeURIComponent(detailUrl)}` }] }],
-      }],
+      list: [vodItem],
     };
   } catch (e) {
     await OmniBox.log("error", `[4K指南][detail] ${e.message}`);
@@ -503,6 +633,7 @@ async function play(params, context) {
     const idParts = playId.split("|");
     const shareURL = idParts[0] || "";
     let fileId = idParts[1] || "";
+    const playMeta = idParts.length >= 3 ? decodePlayMeta(idParts[2] || "") : {};
 
     if (!shareURL) {
       throw new Error("播放参数缺少分享链接");
@@ -524,7 +655,71 @@ async function play(params, context) {
       return { parse: 1, jx: 0, url: shareURL, urls: [{ name: "打开网盘", url: shareURL }], header, headers: header, flag: shareURL };
     }
 
-    const playInfo = await OmniBox.getDriveVideoPlayInfo(shareURL, fileId, routeType);
+    const metadataPromise = (async () => {
+      const result = {
+        danmakuList: [],
+        scrapeTitle: "",
+        scrapePic: "",
+        episodeNumber: null,
+        episodeName: playMeta.e || params.episodeName || "",
+      };
+
+      const vodId = String(playMeta.sid || params.vodId || params.videoId || "").trim();
+      if (!vodId) return result;
+
+      try {
+        const metadata = await OmniBox.getScrapeMetadata(vodId);
+        if (!metadata || !metadata.scrapeData || !Array.isArray(metadata.videoMappings)) {
+          await OmniBox.log("info", `[4K指南][play] 弹幕匹配跳过: metadata 不完整, vodId=${vodId}`);
+          return result;
+        }
+
+        const formattedFileId = `${shareURL}|${fileId}`;
+        const matchedMapping = metadata.videoMappings.find((mapping) => mapping && mapping.fileId === formattedFileId);
+        const scrapeData = metadata.scrapeData || {};
+        result.scrapeTitle = scrapeData.title || "";
+        if (scrapeData.posterPath) {
+          result.scrapePic = `https://image.tmdb.org/t/p/w500${scrapeData.posterPath}`;
+        }
+
+        if (!matchedMapping) {
+          await OmniBox.log("info", `[4K指南][play] 弹幕匹配未命中 mapping: ${formattedFileId}`);
+          return result;
+        }
+
+        if (matchedMapping.episodeNumber) {
+          result.episodeNumber = matchedMapping.episodeNumber;
+        }
+        if (matchedMapping.episodeName && !result.episodeName) {
+          result.episodeName = matchedMapping.episodeName;
+        }
+
+        const fileName = buildScrapedFileName(scrapeData, matchedMapping, result.episodeName || "") || buildFileNameForDanmu(scrapeData.title || playMeta.t || "", result.episodeName || "");
+        if (fileName) {
+          await OmniBox.log("info", `[4K指南][play] 生成 fileName 用于弹幕匹配: ${fileName}`);
+          const matchedDanmaku = await OmniBox.getDanmakuByFileName(fileName);
+          if (Array.isArray(matchedDanmaku) && matchedDanmaku.length > 0) {
+            result.danmakuList = matchedDanmaku;
+            await OmniBox.log("info", `[4K指南][play] 弹幕匹配成功, count=${matchedDanmaku.length}`);
+          }
+        }
+      } catch (error) {
+        await OmniBox.log("warn", `[4K指南][play] 弹幕匹配失败: ${error.message}`);
+      }
+
+      return result;
+    })();
+
+    const [playInfoResult, metadataResult] = await Promise.allSettled([
+      OmniBox.getDriveVideoPlayInfo(shareURL, fileId, routeType),
+      metadataPromise,
+    ]);
+
+    if (playInfoResult.status !== "fulfilled") {
+      throw new Error(playInfoResult.reason && playInfoResult.reason.message ? playInfoResult.reason.message : "网盘直链解析失败");
+    }
+
+    const playInfo = playInfoResult.value;
     if (!playInfo || !Array.isArray(playInfo.url) || !playInfo.url.length) {
       throw new Error("网盘直链解析结果为空");
     }
@@ -533,6 +728,44 @@ async function play(params, context) {
       name: item.name || "播放",
       url: item.url,
     }));
+
+    let danmakuList = Array.isArray(playInfo.danmaku) ? playInfo.danmaku : [];
+    let scrapeTitle = "";
+    let scrapePic = "";
+    let episodeNumber = null;
+    let episodeName = playMeta.e || params.episodeName || "";
+    if (metadataResult.status === "fulfilled" && metadataResult.value) {
+      danmakuList = metadataResult.value.danmakuList?.length ? metadataResult.value.danmakuList : danmakuList;
+      scrapeTitle = metadataResult.value.scrapeTitle || "";
+      scrapePic = metadataResult.value.scrapePic || "";
+      episodeNumber = metadataResult.value.episodeNumber ?? null;
+      episodeName = metadataResult.value.episodeName || episodeName;
+    } else if (metadataResult.status === "rejected") {
+      await OmniBox.log("warn", `[4K指南][play] 获取元数据失败(不影响播放): ${metadataResult.reason && metadataResult.reason.message ? metadataResult.reason.message : metadataResult.reason}`);
+    }
+
+    const historyPayload = buildPlayHistoryPayload({
+      sourceId: context?.sourceId,
+      vodId: String(playMeta.sid || params.vodId || params.videoId || shareURL),
+      title: params.title || scrapeTitle || playMeta.t || shareURL,
+      pic: params.pic || scrapePic || playMeta.p || "",
+      episode: playId,
+      episodeName,
+      episodeNumber,
+    });
+    if (historyPayload) {
+      OmniBox.addPlayHistory(historyPayload)
+        .then((added) => {
+          if (added) {
+            OmniBox.log("info", `[4K指南][play] 已添加观看记录: ${historyPayload.title}`);
+          } else {
+            OmniBox.log("info", `[4K指南][play] 观看记录已存在,跳过添加: ${historyPayload.title}`);
+          }
+        })
+        .catch((error) => {
+          OmniBox.log("warn", `[4K指南][play] 添加观看记录失败: ${error.message}`);
+        });
+    }
 
     const header = playInfo.header || {};
 
@@ -544,7 +777,7 @@ async function play(params, context) {
       header,
       parse: 0,
       jx: 0,
-      danmaku: playInfo.danmaku || [],
+      danmaku: danmakuList,
     };
   } catch (e) {
     await OmniBox.log("error", `[4K指南][play] ${e.message}`);

--- a/影视/网盘/AListTvbox.js
+++ b/影视/网盘/AListTvbox.js
@@ -1,8 +1,8 @@
 // @name AListTvbox
 // @author @sifanss
-// @description 必填参数：BASE_URL，XIAOYA_TOKEN。刮削：支持，弹幕：支持
+// @description 必填参数：BASE_URL，XIAOYA_TOKEN。刮削：支持，弹幕：支持，播放记录：支持
 // @dependencies: axios
-// @version 1.0.6
+// @version 1.1.1
 // @downloadURL https://gh-proxy.org/https://github.com/Silent1566/OmniBox-Spider/raw/refs/heads/main/影视/网盘/AListTvbox.js
 
 // 引入 OmniBox SDK
@@ -696,7 +696,7 @@ function isValidUrl(str) {
 /**
  * 播放
  */
-async function play(params) {
+async function play(params, context) {
   try {
     const playId = params.playId || params.id || "";
     const flag = params.flag || "";
@@ -719,7 +719,6 @@ async function play(params) {
 
     OmniBox.log("info", `获取播放地址: playId=${mainPlayId}, flag=${flag}`);
 
-    // 直接播放链接（m3u8/mp4 等）直接返回
     if (/\.(m3u8|mp4|rmvb|avi|wmv|flv|mkv|webm|mov|m3u|mp3)(?!\w)/i.test(mainPlayId)) {
       return {
         urls: [{ name: "播放", url: mainPlayId }],
@@ -733,20 +732,18 @@ async function play(params) {
       mainPlayId = mainPlayId.split('/').pop()
     }
 
-    const data = await requestXiaoya(PLAY_PATH, { id: mainPlayId });
-    const urls = buildPlayUrls(data.url);
-    const header = typeof data.header === "string" ? JSON.parse(data.header) : data.header || {};
-
-
-    OmniBox.log("info", `urls:${JSON.stringify(urls)}`)
-
-    // 弹幕匹配
-    let danmakuList = [];
-    let scrapeTitle = "";
-    let scrapePic = "";
-    try {
+    const metadataPromise = (async () => {
+      const result = {
+        danmakuList: [],
+        scrapeTitle: "",
+        scrapePic: "",
+        episodeNumber: null,
+        episodeName: originalEpisodeName || params.episodeName || "",
+      };
       const vodId = params.vodId || "";
-      if (vodId) {
+      if (!vodId) return result;
+
+      try {
         const metadata = await OmniBox.getScrapeMetadata(vodId);
         if (metadata && metadata.scrapeData && metadata.videoMappings) {
           const formattedFileId = `${vodId}|${mainPlayId}`;
@@ -759,13 +756,17 @@ async function play(params) {
           }
 
           if (metadata.scrapeData) {
-            scrapeTitle = metadata.scrapeData.title || "";
+            result.scrapeTitle = metadata.scrapeData.title || "";
             if (metadata.scrapeData.posterPath) {
-              scrapePic = `https://image.tmdb.org/t/p/w500${metadata.scrapeData.posterPath}`;
+              result.scrapePic = `https://image.tmdb.org/t/p/w500${metadata.scrapeData.posterPath}`;
             }
           }
 
           if (matchedMapping && metadata.scrapeData) {
+            result.episodeNumber = matchedMapping.episodeNumber ?? null;
+            if (matchedMapping.episodeName && !result.episodeName) {
+              result.episodeName = matchedMapping.episodeName;
+            }
             const scrapeData = metadata.scrapeData;
             let fileName = "";
             const scrapeType = metadata.scrapeType || "";
@@ -781,13 +782,42 @@ async function play(params) {
 
             if (fileName) {
               OmniBox.log("info", `生成fileName用于弹幕匹配: ${fileName}`);
-              danmakuList = await OmniBox.getDanmakuByFileName(fileName);
+              result.danmakuList = await OmniBox.getDanmakuByFileName(fileName);
             }
           }
         }
+      } catch (error) {
+        OmniBox.log("warn", `弹幕匹配失败: ${error.message}`);
       }
-    } catch (error) {
-      OmniBox.log("warn", `弹幕匹配失败: ${error.message}`);
+
+      return result;
+    })();
+
+    const [playResult, metadataResult] = await Promise.allSettled([
+      requestXiaoya(PLAY_PATH, { id: mainPlayId }),
+      metadataPromise,
+    ]);
+    if (playResult.status !== "fulfilled") {
+      throw playResult.reason || new Error("获取播放地址失败");
+    }
+
+    const data = playResult.value;
+    const urls = buildPlayUrls(data.url);
+    const header = typeof data.header === "string" ? JSON.parse(data.header) : data.header || {};
+
+    OmniBox.log("info", `urls:${JSON.stringify(urls)}`)
+
+    let danmakuList = [];
+    let scrapeTitle = "";
+    let scrapePic = "";
+    let episodeNumber = null;
+    let finalEpisodeName = originalEpisodeName || params.episodeName || "";
+    if (metadataResult.status === "fulfilled" && metadataResult.value) {
+      danmakuList = metadataResult.value.danmakuList || [];
+      scrapeTitle = metadataResult.value.scrapeTitle || "";
+      scrapePic = metadataResult.value.scrapePic || "";
+      episodeNumber = metadataResult.value.episodeNumber ?? null;
+      finalEpisodeName = metadataResult.value.episodeName || finalEpisodeName;
     }
 
     if (!danmakuList || danmakuList.length === 0) {
@@ -804,6 +834,38 @@ async function play(params) {
           OmniBox.log("warn", `兜底弹幕匹配失败: ${error.message}`);
         }
       }
+    }
+
+    try {
+      const sourceId = context?.sourceId;
+      const titleForHistory = params.title || scrapeTitle || originalTitle || mainPlayId;
+      const picForHistory = params.pic || scrapePic || "";
+      const vodIdForHistory = String(params.vodId || params.videoId || originalTitle || mainPlayId);
+      if (sourceId) {
+        OmniBox.addPlayHistory({
+          vodId: vodIdForHistory,
+          title: titleForHistory,
+          pic: picForHistory,
+          episode: playId,
+          sourceId,
+          episodeNumber,
+          episodeName: finalEpisodeName,
+        })
+          .then((added) => {
+            if (added) {
+              OmniBox.log("info", `已添加观看记录: ${titleForHistory}`);
+            } else {
+              OmniBox.log("info", `观看记录已存在,跳过添加: ${titleForHistory}`);
+            }
+          })
+          .catch((error) => {
+            OmniBox.log("warn", `添加观看记录失败: ${error.message}`);
+          });
+      } else {
+        OmniBox.log("info", `跳过观看记录: sourceId 缺失, title=${titleForHistory}`);
+      }
+    } catch (error) {
+      OmniBox.log("warn", `观看记录预处理失败: ${error.message}`);
     }
 
     return {

--- a/影视/网盘/剧迷115.js
+++ b/影视/网盘/剧迷115.js
@@ -1,7 +1,7 @@
 // @name 剧迷115
 // @author 梦
-// @description 影视站：gimy115.top，支持首页、分类、搜索、详情与网盘线路提取；Cookie 支持环境变量配置
-// @version 1.1.0
+// @description 影视站：gimy115.top，支持首页、分类、搜索、详情与网盘线路提取；支持刮削、弹幕、播放记录；Cookie 支持环境变量配置
+// @version 1.2.0
 // @dependencies cheerio
 
 const OmniBox = require("omnibox_sdk");
@@ -728,6 +728,7 @@ async function detail(params, context) {
 
     const detailMeta = extractDetailMeta($, detailUrl);
     const playSources = [];
+    const filesForScraping = [];
     const driveTypeCountMap = await collectDriveTypeCountMap(downloadGroups);
     const driveTypeCurrentIndexMap = {};
 
@@ -829,15 +830,30 @@ async function detail(params, context) {
             const episodes = directVideoFiles.map((file) => {
               const episodeName = decodeHtml(String(file.file_name || "资源").replace(/\.[^.]+$/, "")) || "资源";
               const size = formatFileSize(file.size);
+              const playMeta = encodePlayMeta({
+                sid: detailUrl,
+                t: detailMeta.vod_name || "",
+                p: detailMeta.vod_pic || "",
+                e: episodeName,
+              });
+              const drivePlayId = buildDrivePlayId({
+                shareURL: normalizedShareURL,
+                fileId: file.fid,
+                episodeName,
+                sourceName: sourceBaseName,
+                routeType,
+              });
+              const finalPlayId = playMeta ? `${drivePlayId}|||${playMeta}` : drivePlayId;
+              if (!filesForScraping.some((item) => item.fid === `${normalizedShareURL}|${file.fid}`)) {
+                filesForScraping.push({
+                  file_name: episodeName,
+                  fid: `${normalizedShareURL}|${file.fid}`,
+                  file_id: `${normalizedShareURL}|${file.fid}`,
+                });
+              }
               return {
                 name: size ? `${episodeName} [${size}]` : episodeName,
-                playId: buildDrivePlayId({
-                  shareURL: normalizedShareURL,
-                  fileId: file.fid,
-                  episodeName,
-                  sourceName: sourceBaseName,
-                  routeType,
-                }),
+                playId: finalPlayId,
               };
             });
             playSources.push({
@@ -854,6 +870,43 @@ async function detail(params, context) {
     const vod_play_sources = playSources.length
       ? playSources
       : [{ name: "详情页", episodes: [{ name: "打开详情页", playId: `page|||${encodeURIComponent(detailUrl)}` }] }];
+
+    if (filesForScraping.length > 0) {
+      try {
+        await OmniBox.log("info", `[Gimy115][detail] 开始统一刮削: vodId=${detailUrl}, files=${filesForScraping.length}`);
+        await OmniBox.processScraping(detailUrl, detailMeta.vod_name || "", detailMeta.vod_name || "", filesForScraping);
+        const metadata = await OmniBox.getScrapeMetadata(detailUrl);
+        const scrapeData = metadata?.scrapeData || null;
+        const videoMappings = Array.isArray(metadata?.videoMappings) ? metadata.videoMappings : [];
+
+        if (scrapeData || videoMappings.length > 0) {
+          for (const source of vod_play_sources) {
+            for (const episode of source.episodes || []) {
+              const parts = String(episode.playId || "").split("|||");
+              const drivePayload = parseDrivePlayId(parts[0] || "");
+              const formattedId = `${String(drivePayload?.shareURL || "")}|${String(drivePayload?.fileId || "")}`;
+              const matchedMapping = videoMappings.find((mapping) => mapping && mapping.fileId === formattedId);
+              if (matchedMapping && scrapeData) {
+                const newName = buildScrapedFileName(scrapeData, matchedMapping, String(episode.name || ""));
+                if (newName && newName !== episode.name) {
+                  episode.name = newName;
+                }
+              }
+            }
+          }
+
+          if (scrapeData) {
+            if (scrapeData.title) detailMeta.vod_name = scrapeData.title;
+            if (scrapeData.posterPath) detailMeta.vod_pic = `https://image.tmdb.org/t/p/w500${scrapeData.posterPath}`;
+            if (scrapeData.overview) detailMeta.vod_content = scrapeData.overview;
+            if (scrapeData.releaseDate) detailMeta.vod_year = String(scrapeData.releaseDate).slice(0, 4);
+            if (scrapeData.voteAverage) detailMeta.vod_douban_score = Number(scrapeData.voteAverage).toFixed(1);
+          }
+        }
+      } catch (error) {
+        await OmniBox.log("warn", `[Gimy115][detail] 统一刮削失败: ${error.message}`);
+      }
+    }
 
     await OmniBox.log("info", `[Gimy115][detail] input=${inputUrl} detail=${detailUrl} shareGroups=${downloadGroups.length} playSources=${playSources.length}`);
     return {
@@ -874,14 +927,68 @@ async function play(params, context) {
     const playId = String(params.playId || params.id || params.url || "").trim();
     if (!playId) return { parse: 0, url: "", urls: [], header: {}, headers: {}, flag: "gimy115" };
 
-    const driveMeta = parseDrivePlayId(playId);
+    const [mainPlayId, metaPart = ""] = playId.split("|||");
+    const playMeta = decodePlayMeta(metaPart);
+    const driveMeta = parseDrivePlayId(mainPlayId);
     if (driveMeta && driveMeta.shareURL && driveMeta.fileId) {
       const shareURL = String(driveMeta.shareURL || "");
       const fileId = String(driveMeta.fileId || "");
       const routeType = String(driveMeta.routeType || (String(context?.from || "web") === "web" ? "服务端代理" : "直连"));
-      const episodeName = String(driveMeta.episodeName || "播放");
+      const episodeName = String(playMeta.e || driveMeta.episodeName || "播放");
       await OmniBox.log("info", `[Gimy115][play] drive route=${routeType} shareURL=${shareURL} fileId=${fileId}`);
-      const playInfo = await OmniBox.getDriveVideoPlayInfo(shareURL, fileId, routeType);
+
+      const metadataPromise = (async () => {
+        const result = {
+          danmakuList: [],
+          scrapeTitle: "",
+          scrapePic: "",
+          episodeNumber: null,
+          episodeName,
+        };
+        const vodId = String(playMeta.sid || params.vodId || params.videoId || "").trim();
+        if (!vodId) return result;
+
+        try {
+          const metadata = await OmniBox.getScrapeMetadata(vodId);
+          if (!metadata || !metadata.scrapeData || !Array.isArray(metadata.videoMappings)) {
+            await OmniBox.log("info", `[Gimy115][play] 弹幕匹配跳过: metadata 不完整, vodId=${vodId}`);
+            return result;
+          }
+          const formattedId = `${shareURL}|${fileId}`;
+          const matchedMapping = metadata.videoMappings.find((mapping) => mapping && mapping.fileId === formattedId);
+          const scrapeData = metadata.scrapeData || {};
+          result.scrapeTitle = scrapeData.title || "";
+          if (scrapeData.posterPath) {
+            result.scrapePic = `https://image.tmdb.org/t/p/w500${scrapeData.posterPath}`;
+          }
+          if (!matchedMapping) return result;
+          result.episodeNumber = matchedMapping.episodeNumber ?? null;
+          if (matchedMapping.episodeName && !result.episodeName) {
+            result.episodeName = matchedMapping.episodeName;
+          }
+          const fileName = buildScrapedFileName(scrapeData, matchedMapping, result.episodeName || "") || buildFileNameForDanmu(scrapeData.title || playMeta.t || "", result.episodeName || "");
+          if (fileName) {
+            await OmniBox.log("info", `[Gimy115][play] 生成 fileName 用于弹幕匹配: ${fileName}`);
+            const matchedDanmaku = await OmniBox.getDanmakuByFileName(fileName);
+            if (Array.isArray(matchedDanmaku) && matchedDanmaku.length > 0) {
+              result.danmakuList = matchedDanmaku;
+            }
+          }
+        } catch (error) {
+          await OmniBox.log("warn", `[Gimy115][play] 弹幕匹配失败: ${error.message}`);
+        }
+
+        return result;
+      })();
+
+      const [playInfoResult, metadataResult] = await Promise.allSettled([
+        OmniBox.getDriveVideoPlayInfo(shareURL, fileId, routeType),
+        metadataPromise,
+      ]);
+      if (playInfoResult.status !== "fulfilled") {
+        throw new Error(playInfoResult.reason && playInfoResult.reason.message ? playInfoResult.reason.message : `未获取到网盘播放地址: ${shareURL}`);
+      }
+      const playInfo = playInfoResult.value;
       const urlsRaw = Array.isArray(playInfo?.urls) ? playInfo.urls : Array.isArray(playInfo?.url) ? playInfo.url : [];
       const urls = urlsRaw.map((item) => ({
         name: String(item?.name || episodeName || "播放"),
@@ -889,6 +996,41 @@ async function play(params, context) {
       })).filter((item) => item.url);
       if (urls.length) {
         const header = playInfo?.header || playInfo?.headers || {};
+        let danmakuList = playInfo?.danmaku;
+        let scrapeTitle = "";
+        let scrapePic = "";
+        let episodeNumber = null;
+        let finalEpisodeName = episodeName;
+        if (metadataResult.status === "fulfilled" && metadataResult.value) {
+          danmakuList = metadataResult.value.danmakuList?.length ? metadataResult.value.danmakuList : danmakuList;
+          scrapeTitle = metadataResult.value.scrapeTitle || "";
+          scrapePic = metadataResult.value.scrapePic || "";
+          episodeNumber = metadataResult.value.episodeNumber ?? null;
+          finalEpisodeName = metadataResult.value.episodeName || finalEpisodeName;
+        }
+
+        if (context?.sourceId) {
+          OmniBox.addPlayHistory({
+            vodId: String(playMeta.sid || params.vodId || params.videoId || shareURL),
+            title: params.title || scrapeTitle || playMeta.t || shareURL,
+            pic: params.pic || scrapePic || playMeta.p || "",
+            episode: playId,
+            sourceId: context.sourceId,
+            episodeNumber,
+            episodeName: finalEpisodeName,
+          })
+            .then((added) => {
+              if (added) {
+                OmniBox.log("info", `[Gimy115][play] 已添加观看记录: ${params.title || scrapeTitle || playMeta.t || shareURL}`);
+              } else {
+                OmniBox.log("info", `[Gimy115][play] 观看记录已存在,跳过添加: ${params.title || scrapeTitle || playMeta.t || shareURL}`);
+              }
+            })
+            .catch((error) => {
+              OmniBox.log("warn", `[Gimy115][play] 添加观看记录失败: ${error.message}`);
+            });
+        }
+
         return {
           parse: Number(playInfo?.parse || 0),
           url: String(playInfo?.url || urls[0].url || ""),
@@ -896,7 +1038,7 @@ async function play(params, context) {
           header,
           headers: header,
           flag: String(playInfo?.flag || routeType || "drive"),
-          danmaku: playInfo?.danmaku,
+          danmaku: danmakuList,
         };
       }
       throw new Error(`未获取到网盘播放地址: ${shareURL}`);
@@ -905,97 +1047,29 @@ async function play(params, context) {
     if (playId.startsWith("denied|||")) {
       const parts = playId.split("|||");
       const deniedUrl = decodeURIComponent(parts[1] || "");
-      const message = decodeURIComponent(parts[2] || "当前页面需要更高权限或有效 Cookie");
       return {
-        parse: 0,
-        url: "",
-        urls: [],
-        flag: "permission-denied",
-        header: {},
-        headers: {},
-        message: `Gimy115 当前返回权限页：${message}`,
-        error: `Gimy115 当前返回权限页：${message}`,
-        note: `请配置环境变量 GIMY115_COOKIE，或确认该资源是否仅会员可见：${deniedUrl}`,
+        parse: 1,
+        url: deniedUrl,
+        urls: [{ name: "权限页", url: deniedUrl }],
+        header: getHeaders(deniedUrl),
+        headers: getHeaders(deniedUrl),
+        flag: "denied",
       };
     }
 
     if (playId.startsWith("page|||")) {
       const pageUrl = decodeURIComponent(playId.slice("page|||".length));
-      const header = getHeaders(pageUrl, { Origin: BASE_URL });
       return {
         parse: 1,
         url: pageUrl,
         urls: [{ name: "详情页", url: pageUrl }],
-        header,
-        headers: header,
+        header: getHeaders(pageUrl),
+        headers: getHeaders(pageUrl),
         flag: "page",
       };
     }
 
-    const pageUrl = /^https?:\/\//i.test(playId) ? playId : absUrl(playId);
-    const html = await requestText(pageUrl, { referer: pageUrl });
-
-    if (isPermissionDenied(html)) {
-      const msg = extractPermissionMessage(html);
-      return {
-        parse: 0,
-        url: "",
-        urls: [],
-        flag: "permission-denied",
-        header: {},
-        headers: {},
-        message: `Gimy115 当前返回权限页：${msg}`,
-        error: `Gimy115 当前返回权限页：${msg}`,
-      };
-    }
-
-    const m = html.match(/var\s+player_data\s*=\s*(\{[\s\S]*?\})\s*<\/script>/i);
-    if (m) {
-      try {
-        const playerData = JSON.parse(m[1]);
-        const rawUrl = String(playerData.url || "").trim();
-        if (rawUrl) {
-          const header = getHeaders(pageUrl, { Origin: BASE_URL });
-          return {
-            parse: 1,
-            url: rawUrl,
-            urls: [{ name: decodeHtml(playerData.from || "播放"), url: rawUrl }],
-            header,
-            headers: header,
-            flag: String(playerData.from || "page"),
-          };
-        }
-      } catch (e) {
-        await OmniBox.log("warn", `[Gimy115][play] player_data parse failed: ${e.message}`);
-      }
-    }
-
-    try {
-      const sniffed = await OmniBox.sniffVideo(pageUrl, getHeaders(pageUrl));
-      if (sniffed && sniffed.url) {
-        const header = sniffed.header || getHeaders(pageUrl, { Origin: BASE_URL });
-        return {
-          parse: 0,
-          url: sniffed.url,
-          urls: [{ name: "嗅探播放", url: sniffed.url }],
-          header,
-          headers: header,
-          flag: "sniff",
-        };
-      }
-    } catch (e) {
-      await OmniBox.log("warn", `[Gimy115][play] sniff failed: ${e.message}`);
-    }
-
-    const header = getHeaders(pageUrl, { Origin: BASE_URL });
-    return {
-      parse: 1,
-      url: pageUrl,
-      urls: [{ name: "播放页", url: pageUrl }],
-      header,
-      headers: header,
-      flag: "page",
-    };
+    return { parse: 0, url: playId, urls: [{ name: "播放", url: playId }], header: {}, headers: {}, flag: "gimy115" };
   } catch (e) {
     await OmniBox.log("error", `[Gimy115][play] ${e.message}`);
     return { parse: 0, url: "", urls: [], header: {}, headers: {}, flag: "gimy115" };


### PR DESCRIPTION
## 变更概述
- 补齐 `4K指南`、`剧迷115`、`AListTvbox` 三个网盘源缺失的刮削、弹幕、播放记录能力
- 将播放地址与弹幕获取改为并行执行，提升启播效率
- 将播放记录改为异步记录，并补充成功/已存在/跳过/失败日志
- 统一补齐 detail 阶段的刮削与元数据处理链路

## 具体调整
### 4K指南
- 补齐 detail 阶段统一刮削与 metadata 获取
- 增加统一刮削日志
- 播放阶段并行获取播放地址与弹幕
- 增加异步播放记录日志

### 剧迷115
- 补齐统一刮削流程
- 播放阶段并行获取播放地址与弹幕
- 增加异步播放记录日志

### AListTvbox
- 补齐播放记录能力
- 放宽播放记录入口条件，避免 `vodId` 缺失时整段跳过
- 增加成功/已存在/跳过/失败日志
- 播放阶段并行获取播放地址与弹幕

## 验证
- `node --check '影视/网盘/4K指南.js'`
- `node --check '影视/网盘/剧迷115.js'`
- `node --check '影视/网盘/AListTvbox.js'`

## 备注
- 目前已完成语法校验
- `AListTvbox` 的真实 play 新日志回归仍可继续补充验证
