### PR TITLE
fix: 修复毒舌03图片域名与筛选链路

### DIFF
--- a/影视/采集/毒舌03.js
+++ b/影视/采集/毒舌03.js
@@ -1,0 +1,669 @@
+// @name 毒舌03
+// @author 梦
+// @description 影视站：https://www.dushe03.com/ ，支持首页、分类、详情、搜索与播放
+// @dependencies cheerio
+// @version 1.0.7
+// @downloadURL https://gh-proxy.org/https://github.com/Silent1566/OmniBox-Spider/raw/refs/heads/main/影视/采集/毒舌03.js
+
+const OmniBox = require("omnibox_sdk");
+const runner = require("spider_runner");
+const cheerio = require("cheerio");
+const crypto = require("crypto");
+
+const BASE_URL = (process.env.DUSHE03_HOST || "https://www.dushe03.com").replace(/\/$/, "");
+const UA = process.env.DUSHE03_UA || "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.0.0 Safari/537.36";
+const HOME_CACHE_TTL = Number(process.env.DUSHE03_HOME_CACHE_TTL || 900);
+const CATEGORY_CACHE_TTL = Number(process.env.DUSHE03_CATEGORY_CACHE_TTL || 900);
+const DETAIL_CACHE_TTL = Number(process.env.DUSHE03_DETAIL_CACHE_TTL || 1800);
+const SEARCH_CACHE_TTL = Number(process.env.DUSHE03_SEARCH_CACHE_TTL || 600);
+const PLAY_CACHE_TTL = Number(process.env.DUSHE03_PLAY_CACHE_TTL || 900);
+
+const CATEGORY_CONFIG = [
+  { id: "1", name: "电影" },
+  { id: "2", name: "剧集" },
+  { id: "3", name: "综艺" },
+  { id: "4", name: "动漫" },
+  { id: "6", name: "短剧" },
+];
+
+const CLASS_LIST = CATEGORY_CONFIG.map((item) => ({ type_id: item.id, type_name: item.name }));
+const CATEGORY_SHOW_PATH = Object.fromEntries(CATEGORY_CONFIG.map((item) => [item.id, `/show/${item.id}------.html`]));
+const STATIC_HOST = process.env.DUSHE03_STATIC_HOST || "https://vres.bavdxfg.cn";
+const PIC_HEADERS = {
+  Referer: `${BASE_URL}/`,
+  Origin: BASE_URL,
+  "User-Agent": UA,
+};
+const FILTERS = {
+  "1": [
+    { key: "type", name: "类型", init: "", value: [{ name: "全部", value: "" }, { name: "剧情", value: "剧情" }, { name: "爱情", value: "爱情" }, { name: "喜剧", value: "喜剧" }, { name: "动作", value: "动作" }, { name: "恐怖", value: "恐怖" }, { name: "科幻", value: "科幻" }, { name: "悬疑", value: "悬疑" }, { name: "惊悚", value: "惊悚" }, { name: "犯罪", value: "犯罪" }, { name: "冒险", value: "冒险" }, { name: "动画", value: "动画" }, { name: "奇幻", value: "奇幻" }, { name: "武侠", value: "武侠" }] },
+    { key: "area", name: "地区", init: "", value: [{ name: "地区", value: "" }, { name: "大陆", value: "中国大陆" }, { name: "香港", value: "中国香港" }, { name: "韩国", value: "韩国" }, { name: "美国", value: "美国" }, { name: "日本", value: "日本" }, { name: "法国", value: "法国" }, { name: "英国", value: "英国" }, { name: "德国", value: "德国" }, { name: "台湾", value: "中国台湾" }, { name: "泰国", value: "泰国" }, { name: "印度", value: "印度" }, { name: "其他", value: "其他" }] },
+    { key: "lang", name: "语言", init: "", value: [{ name: "全部", value: "" }, { name: "国语", value: "国语" }, { name: "粤语", value: "粤语" }, { name: "英语", value: "英语" }, { name: "日语", value: "日语" }, { name: "韩语", value: "韩语" }, { name: "法语", value: "法语" }, { name: "其他", value: "其他" }] },
+    { key: "year", name: "年份", init: "", value: [{ name: "全部", value: "" }, { name: "2026", value: "2026" }, { name: "2025", value: "2025" }, { name: "2024", value: "2024" }, { name: "2023", value: "2023" }, { name: "2022", value: "2022" }, { name: "2021", value: "2021" }, { name: "2020", value: "2020" }, { name: "10年代", value: "2010_2019" }, { name: "00年代", value: "2000_2009" }, { name: "90年代", value: "1990_1999" }, { name: "80年代", value: "1980_1989" }, { name: "更早", value: "0_1979" }] },
+    { key: "by", name: "排序", init: "3", value: [{ name: "综合", value: "1" }, { name: "最新", value: "2" }, { name: "最热", value: "3" }, { name: "评分", value: "4" }] },
+  ],
+  "2": [
+    { key: "type", name: "类型", init: "", value: [{ name: "全部", value: "" }, { name: "剧情", value: "剧情" }, { name: "爱情", value: "爱情" }, { name: "喜剧", value: "喜剧" }, { name: "犯罪", value: "犯罪" }, { name: "悬疑", value: "悬疑" }, { name: "古装", value: "古装" }, { name: "动作", value: "动作" }, { name: "家庭", value: "家庭" }, { name: "惊悚", value: "惊悚" }, { name: "奇幻", value: "奇幻" }, { name: "美剧", value: "美剧" }, { name: "科幻", value: "科幻" }, { name: "历史", value: "历史" }, { name: "战争", value: "战争" }, { name: "韩剧", value: "韩剧" }, { name: "武侠", value: "武侠" }, { name: "言情", value: "言情" }, { name: "恐怖", value: "恐怖" }, { name: "冒险", value: "冒险" }, { name: "都市", value: "都市" }, { name: "职场", value: "职场" }] },
+    { key: "area", name: "地区", init: "", value: [{ name: "地区", value: "" }, { name: "大陆", value: "中国大陆" }, { name: "香港", value: "中国香港" }, { name: "韩国", value: "韩国" }, { name: "美国", value: "美国" }, { name: "日本", value: "日本" }, { name: "法国", value: "法国" }, { name: "英国", value: "英国" }, { name: "德国", value: "德国" }, { name: "台湾", value: "中国台湾" }, { name: "泰国", value: "泰国" }, { name: "印度", value: "印度" }, { name: "其他", value: "其他" }] },
+    { key: "lang", name: "语言", init: "", value: [{ name: "全部", value: "" }, { name: "国语", value: "国语" }, { name: "粤语", value: "粤语" }, { name: "英语", value: "英语" }, { name: "日语", value: "日语" }, { name: "韩语", value: "韩语" }, { name: "法语", value: "法语" }, { name: "其他", value: "其他" }] },
+    { key: "year", name: "年份", init: "", value: [{ name: "全部", value: "" }, { name: "2026", value: "2026" }, { name: "2025", value: "2025" }, { name: "2024", value: "2024" }, { name: "2023", value: "2023" }, { name: "2022", value: "2022" }, { name: "2021", value: "2021" }, { name: "2020", value: "2020" }, { name: "10年代", value: "2010_2019" }, { name: "00年代", value: "2000_2009" }, { name: "90年代", value: "1990_1999" }, { name: "80年代", value: "1980_1989" }, { name: "更早", value: "0_1979" }] },
+    { key: "by", name: "排序", init: "3", value: [{ name: "综合", value: "1" }, { name: "最新", value: "2" }, { name: "最热", value: "3" }, { name: "评分", value: "4" }] },
+  ],
+  "3": [
+    { key: "type", name: "类型", init: "", value: [{ name: "全部", value: "" }, { name: "真人秀", value: "真人秀" }, { name: "脱口秀", value: "脱口秀" }, { name: "选秀", value: "选秀" }, { name: "美食", value: "美食" }, { name: "旅游", value: "旅游" }, { name: "晚会", value: "晚会" }, { name: "音乐", value: "音乐" }, { name: "纪实", value: "纪实" }] },
+    { key: "area", name: "地区", init: "", value: [{ name: "地区", value: "" }, { name: "大陆", value: "中国大陆" }, { name: "香港", value: "中国香港" }, { name: "韩国", value: "韩国" }, { name: "美国", value: "美国" }, { name: "日本", value: "日本" }, { name: "台湾", value: "中国台湾" }, { name: "泰国", value: "泰国" }, { name: "其他", value: "其他" }] },
+    { key: "lang", name: "语言", init: "", value: [{ name: "全部", value: "" }, { name: "国语", value: "国语" }, { name: "粤语", value: "粤语" }, { name: "英语", value: "英语" }, { name: "日语", value: "日语" }, { name: "韩语", value: "韩语" }, { name: "其他", value: "其他" }] },
+    { key: "year", name: "年份", init: "", value: [{ name: "全部", value: "" }, { name: "2026", value: "2026" }, { name: "2025", value: "2025" }, { name: "2024", value: "2024" }, { name: "2023", value: "2023" }, { name: "2022", value: "2022" }, { name: "2021", value: "2021" }, { name: "2020", value: "2020" }, { name: "10年代", value: "2010_2019" }, { name: "00年代", value: "2000_2009" }, { name: "90年代", value: "1990_1999" }, { name: "80年代", value: "1980_1989" }, { name: "更早", value: "0_1979" }] },
+    { key: "by", name: "排序", init: "3", value: [{ name: "综合", value: "1" }, { name: "最新", value: "2" }, { name: "最热", value: "3" }, { name: "评分", value: "4" }] },
+  ],
+  "4": [
+    { key: "type", name: "类型", init: "", value: [{ name: "全部", value: "" }, { name: "热血", value: "热血" }, { name: "搞笑", value: "搞笑" }, { name: "冒险", value: "冒险" }, { name: "奇幻", value: "奇幻" }, { name: "恋爱", value: "恋爱" }, { name: "校园", value: "校园" }, { name: "科幻", value: "科幻" }, { name: "战斗", value: "战斗" }] },
+    { key: "area", name: "地区", init: "", value: [{ name: "地区", value: "" }, { name: "大陆", value: "中国大陆" }, { name: "日本", value: "日本" }, { name: "美国", value: "美国" }, { name: "韩国", value: "韩国" }, { name: "其他", value: "其他" }] },
+    { key: "lang", name: "语言", init: "", value: [{ name: "全部", value: "" }, { name: "国语", value: "国语" }, { name: "日语", value: "日语" }, { name: "英语", value: "英语" }, { name: "其他", value: "其他" }] },
+    { key: "year", name: "年份", init: "", value: [{ name: "全部", value: "" }, { name: "2026", value: "2026" }, { name: "2025", value: "2025" }, { name: "2024", value: "2024" }, { name: "2023", value: "2023" }, { name: "2022", value: "2022" }, { name: "2021", value: "2021" }, { name: "2020", value: "2020" }, { name: "10年代", value: "2010_2019" }, { name: "00年代", value: "2000_2009" }, { name: "90年代", value: "1990_1999" }, { name: "80年代", value: "1980_1989" }, { name: "更早", value: "0_1979" }] },
+    { key: "by", name: "排序", init: "3", value: [{ name: "综合", value: "1" }, { name: "最新", value: "2" }, { name: "最热", value: "3" }, { name: "评分", value: "4" }] },
+  ],
+  "6": [
+    { key: "type", name: "类型", init: "", value: [{ name: "全部", value: "" }, { name: "爱情", value: "爱情" }, { name: "都市", value: "都市" }, { name: "逆袭", value: "逆袭" }, { name: "悬疑", value: "悬疑" }, { name: "古装", value: "古装" }, { name: "穿越", value: "穿越" }, { name: "甜宠", value: "甜宠" }] },
+    { key: "area", name: "地区", init: "", value: [{ name: "地区", value: "" }, { name: "大陆", value: "中国大陆" }, { name: "台湾", value: "中国台湾" }, { name: "香港", value: "中国香港" }, { name: "其他", value: "其他" }] },
+    { key: "lang", name: "语言", init: "", value: [{ name: "全部", value: "" }, { name: "国语", value: "国语" }, { name: "粤语", value: "粤语" }, { name: "其他", value: "其他" }] },
+    { key: "year", name: "年份", init: "", value: [{ name: "全部", value: "" }, { name: "2026", value: "2026" }, { name: "2025", value: "2025" }, { name: "2024", value: "2024" }, { name: "2023", value: "2023" }, { name: "2022", value: "2022" }, { name: "2021", value: "2021" }, { name: "2020", value: "2020" }, { name: "10年代", value: "2010_2019" }, { name: "00年代", value: "2000_2009" }, { name: "90年代", value: "1990_1999" }, { name: "80年代", value: "1980_1989" }, { name: "更早", value: "0_1979" }] },
+    { key: "by", name: "排序", init: "3", value: [{ name: "综合", value: "1" }, { name: "最新", value: "2" }, { name: "最热", value: "3" }, { name: "评分", value: "4" }] },
+  ],
+};
+
+let cdndefendCookie = "";
+
+module.exports = { home, category, detail, search, play };
+runner.run(module.exports);
+
+function absUrl(raw = "") {
+  const value = String(raw || "").trim();
+  if (!value) return "";
+  if (/^https?:\/\//i.test(value)) return value;
+  if (value.startsWith("//")) return `https:${value}`;
+  if (value.startsWith("/vod1/")) {
+    return new URL(value, `${STATIC_HOST}/`).toString();
+  }
+  try {
+    return new URL(value, `${BASE_URL}/`).toString();
+  } catch (_) {
+    return value;
+  }
+}
+
+function cleanText(value) {
+  return String(value || "")
+    .replace(/&nbsp;/gi, " ")
+    .replace(/&#160;/gi, " ")
+    .replace(/<br\s*\/?>/gi, "\n")
+    .replace(/<[^>]+>/g, " ")
+    .replace(/\r/g, "")
+    .replace(/[ \t\f\v]+/g, " ")
+    .replace(/\n\s*\n+/g, "\n")
+    .trim();
+}
+
+function decodeHtmlEntities(value) {
+  return String(value || "")
+    .replace(/&amp;/gi, "&")
+    .replace(/&quot;/gi, '"')
+    .replace(/&#39;/gi, "'")
+    .replace(/&lt;/gi, "<")
+    .replace(/&gt;/gi, ">");
+}
+
+function encodeSegment(value) {
+  return encodeURIComponent(String(value || "").trim());
+}
+
+function summarizeImageCandidates($, root, selectors = []) {
+  const scope = root && typeof root.find === "function" ? root : $(root);
+  const summary = [];
+  for (const selector of selectors) {
+    const nodes = scope.find(selector).toArray().slice(0, 3);
+    for (const el of nodes) {
+      const wrapped = $(el);
+      summary.push({
+        selector,
+        self: {
+          dataOriginal: String(wrapped.attr("data-original") || ""),
+          dataSrc: String(wrapped.attr("data-src") || ""),
+          src: String(wrapped.attr("src") || ""),
+        },
+        parentA: {
+          dataOriginal: String(wrapped.parent("a").attr("data-original") || ""),
+          dataSrc: String(wrapped.parent("a").attr("data-src") || ""),
+          src: String(wrapped.parent("a").attr("src") || ""),
+        },
+        closestA: {
+          dataOriginal: String(wrapped.closest("a").attr("data-original") || ""),
+          dataSrc: String(wrapped.closest("a").attr("data-src") || ""),
+          src: String(wrapped.closest("a").attr("src") || ""),
+        },
+      });
+      if (summary.length >= 4) return summary;
+    }
+  }
+  return summary;
+}
+
+function pickImage($, root, selectors = []) {
+  const scope = root && typeof root.find === "function" ? root : $(root);
+  for (const selector of selectors) {
+    const nodes = scope.find(selector).toArray();
+    for (const el of nodes) {
+      const wrapped = $(el);
+      const candidateGroups = [
+        [wrapped.attr("data-original"), wrapped.attr("data-src"), wrapped.attr("src"), wrapped.attr("data-url"), wrapped.attr("data-lazy-src"), wrapped.attr("original")],
+        [wrapped.parent("a").attr("data-original"), wrapped.parent("a").attr("data-src"), wrapped.parent("a").attr("src")],
+        [wrapped.closest("a").attr("data-original"), wrapped.closest("a").attr("data-src"), wrapped.closest("a").attr("src")],
+      ];
+      for (const candidates of candidateGroups) {
+        for (const raw of candidates.map((item) => String(item || "").trim()).filter(Boolean)) {
+          if (/logo_placeholder|noneCoverImg|blank\.gif|base64|avatar\.png|empty-box/i.test(raw)) continue;
+          return raw;
+        }
+      }
+    }
+  }
+  return "";
+}
+
+function dedupeVodList(list) {
+  const out = [];
+  const seen = new Set();
+  for (const item of Array.isArray(list) ? list : []) {
+    const key = String(item?.vod_id || item?.vod_name || "");
+    if (!key || seen.has(key)) continue;
+    seen.add(key);
+    out.push(item);
+  }
+  return out;
+}
+
+function dedupeEpisodes(episodes) {
+  const out = [];
+  const seen = new Set();
+  for (const ep of Array.isArray(episodes) ? episodes : []) {
+    const name = cleanText(ep?.name || "");
+    const playId = String(ep?.playId || "").trim();
+    const key = `${name}|${playId}`;
+    if (!name || !playId || seen.has(key)) continue;
+    seen.add(key);
+    out.push({ ...ep, name, playId });
+  }
+  return out;
+}
+
+function encodeSearchToken(keyword) {
+  return "";
+}
+
+function extractSearchToken(html) {
+  const text = String(html || "");
+  const match = text.match(/<input[^>]+name=["']t["'][^>]*value=["']([^"']+)["']/i);
+  return decodeHtmlEntities(match?.[1] || "").trim();
+}
+
+function getCdndefendCookie(challengeHtml = "") {
+  if (cdndefendCookie) return cdndefendCookie;
+  const text = String(challengeHtml || "");
+  const prefix = (
+    process.env.DUSHE03_CDNDEFEND_PREFIX
+    || (text.match(/\['([A-F0-9]{40})','cdndefend_js_cookie='/i)?.[1])
+    || (text.match(/const\s+[a-zA-Z0-9_$]+\s*=\s*\['([A-F0-9]{40})','cdndefend_js_cookie='/i)?.[1])
+    || ""
+  ).trim();
+  if (!prefix) return "";
+  const idx = parseInt(prefix[0], 16);
+  let counter = 0;
+  while (counter < 5_000_000) {
+    const candidate = `${prefix}${counter}`;
+    const digest = crypto.createHash("sha1").update(candidate).digest();
+    if (digest[idx] === 0xb0 && digest[idx + 1] === 0x0b) {
+      cdndefendCookie = candidate;
+      return candidate;
+    }
+    counter += 1;
+  }
+  return "";
+}
+
+async function requestText(url, options = {}) {
+  const method = options.method || "GET";
+  const retry850 = options.retry850 !== false;
+  await OmniBox.log("info", `[毒舌03][request] ${method} ${url}`);
+  const headers = {
+    "User-Agent": UA,
+    Accept: "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8",
+    "Accept-Language": "zh-CN,zh;q=0.9,en;q=0.8",
+    "Cache-Control": "no-cache",
+    Pragma: "no-cache",
+    Referer: options.referer || `${BASE_URL}/`,
+    "Upgrade-Insecure-Requests": "1",
+    ...(options.headers || {}),
+  };
+  const res = await OmniBox.request(url, {
+    method,
+    headers,
+    body: options.body,
+    timeout: options.timeout || 20000,
+  });
+  const statusCode = Number(res?.statusCode || 0);
+  const body = res?.body;
+  const text = typeof body === "string" ? body : Buffer.isBuffer(body) ? body.toString() : String(body || "");
+
+  if (statusCode === 850 && retry850) {
+    const cookie = getCdndefendCookie(text);
+    if (cookie) {
+      const retryHeaders = {
+        ...headers,
+        Cookie: [headers.Cookie, `cdndefend_js_cookie=${cookie}`].filter(Boolean).join("; "),
+      };
+      await OmniBox.log("warn", `[毒舌03][request] HTTP 850, retry with cdndefend cookie: ${url}`);
+      const retryRes = await OmniBox.request(url, {
+        method,
+        headers: retryHeaders,
+        body: options.body,
+        timeout: options.timeout || 20000,
+      });
+      const retryStatus = Number(retryRes?.statusCode || 0);
+      const retryBody = retryRes?.body;
+      const retryText = typeof retryBody === "string" ? retryBody : Buffer.isBuffer(retryBody) ? retryBody.toString() : String(retryBody || "");
+      if (retryStatus === 200) return retryText;
+      throw new Error(`HTTP ${retryStatus || 850} @ ${url}`);
+    }
+  }
+
+  if (statusCode !== 200) {
+    throw new Error(`HTTP ${statusCode || "unknown"} @ ${url}`);
+  }
+  return text;
+}
+
+async function getCachedText(cacheKey, ttl, producer) {
+  try {
+    const cached = await OmniBox.getCache(cacheKey);
+    if (cached) return String(cached);
+  } catch (_) {}
+  const text = String(await producer());
+  try {
+    await OmniBox.setCache(cacheKey, text, ttl);
+  } catch (_) {}
+  return text;
+}
+
+function extractYearFromTitle(title) {
+  const match = String(title || "").match(/^(.*?)\s*-\s*.*?(\d{4})年最新/);
+  return match?.[2] || "";
+}
+
+function buildCard($, el, options = {}) {
+  const node = $(el);
+  const anchor = node.find("a[href]").first();
+  const href = anchor.attr("href") || "";
+  const imageNodes = node.find("img");
+  const images = imageNodes.toArray();
+  const poster = images.length > 1 ? $(images[1]) : $(images[0] || []);
+  const title = cleanText(
+    node.find(".v-item-title:not([style*='display: none'])").first().text()
+      || poster.attr("alt")
+      || anchor.attr("title")
+      || ""
+  );
+  const picSelectors = [
+    "a[href]",
+    ".v-item-cover img:not(#noneCoverImg)",
+    ".v-item-main img:not(#noneCoverImg)",
+    "img:not(#noneCoverImg)",
+  ];
+  const pic = pickImage($, node, picSelectors);
+  if (options.logImageDebug) {
+    const debug = summarizeImageCandidates($, node, picSelectors);
+    options.logImageDebug({ title, href, pic, debug });
+  }
+  const remarks = cleanText(node.find(".v-item-bottom span").first().text());
+  const score = cleanText(node.find(".v-item-top-left span").first().text());
+  return {
+    vod_id: absUrl(href),
+    vod_name: title,
+    vod_pic: absUrl(pic),
+    vod_pic_headers: { ...PIC_HEADERS },
+    vod_remarks: remarks || score,
+    vod_douban_score: score.replace(/^豆瓣[:：]?/, ""),
+  };
+}
+
+function parseModuleList(html, options = {}) {
+  const $ = cheerio.load(html);
+  const list = [];
+  $(".module-item").each((_, el) => list.push(buildCard($, el, options)));
+  return dedupeVodList(list).filter((item) => item.vod_id && item.vod_name);
+}
+
+function parseSearchList(html) {
+  const $ = cheerio.load(html);
+  const list = [];
+  $(".search-result-item[href]").each((_, el) => {
+    const node = $(el);
+    const href = node.attr("href") || "";
+    const title = cleanText(node.find(".title").first().text());
+    const pic = pickImage($, node, [
+      ".search-result-item-pic img:not(#noneCoverImg)",
+      ".search-result-item-side img:not(#noneCoverImg)",
+      "img:not(#noneCoverImg)",
+    ]);
+    const tags = node.find(".tags span").map((__, span) => cleanText($(span).text())).get().filter(Boolean);
+    const actor = cleanText(node.find(".actors span").first().text());
+    const desc = cleanText(node.find(".desc").first().text());
+    list.push({
+      vod_id: absUrl(href),
+      vod_name: title,
+      vod_pic: absUrl(pic),
+      vod_pic_headers: { ...PIC_HEADERS },
+      vod_remarks: tags.join("/") || actor,
+      vod_actor: actor,
+      vod_content: desc,
+    });
+  });
+  return dedupeVodList(list).filter((item) => item.vod_id && item.vod_name);
+}
+
+function parsePageCount(html, currentPage) {
+  const text = String(html || "");
+  let pagecount = Math.max(1, Number(currentPage || 1));
+  const patterns = [
+    /href=["'][^"']*channel\/\d+\.html\?page=(\d+)/gi,
+    /href=["'][^"']*channel\/\d+-(\d+)\.html["']/gi,
+    /href=["'][^"']*search\?[^"']*page=(\d+)/gi,
+    /href=["'][^"']*show\/\d+-[^"']*-([1-4])-(\d+)\.html["']/gi,
+  ];
+  for (const pattern of patterns) {
+    for (const match of text.matchAll(pattern)) {
+      const n = Number(match[2] || match[1] || 1);
+      if (Number.isFinite(n)) pagecount = Math.max(pagecount, n);
+    }
+  }
+  return pagecount;
+}
+
+function parseDetailRows($) {
+  const map = {};
+  $(".detail-info-row").each((_, row) => {
+    const label = cleanText($(row).find(".detail-info-row-side").first().text()).replace(/[：:]$/, "");
+    const value = cleanText($(row).find(".detail-info-row-main").first().text());
+    if (label && value) map[label] = value;
+  });
+  return map;
+}
+
+function parseDetailSources($) {
+  const sourceNames = $(".source-list-box-main .source-item .source-item-label")
+    .map((_, el) => cleanText($(el).text()))
+    .get()
+    .filter(Boolean);
+  const episodeLists = $(".episode-list-box-main .episode-list").toArray();
+  const sources = [];
+  episodeLists.forEach((listNode, index) => {
+    const episodes = [];
+    $(listNode).find("a[href]").each((__, a) => {
+      const href = $(a).attr("href") || "";
+      const name = cleanText($(a).text());
+      if (!href || !name) return;
+      episodes.push({ name, playId: absUrl(href) });
+    });
+    if (episodes.length) {
+      sources.push({
+        name: sourceNames[index] || `线路${index + 1}`,
+        episodes: dedupeEpisodes(episodes),
+      });
+    }
+  });
+  return sources;
+}
+
+function parseDetail(html, detailUrl, options = {}) {
+  const $ = cheerio.load(html);
+  const title = cleanText($(".detail-title strong").eq(1).text() || $("title").text().replace(/-.*$/, ""));
+  const picSelectors = [
+    "img:not(#noneCoverImg)",
+    "img[data-original]",
+    "img[data-src]",
+    "img[src]",
+  ];
+  const pic = absUrl(pickImage($, $(".detail-box-side").first(), picSelectors));
+  if (options.logImageDebug) {
+    options.logImageDebug({
+      title,
+      href: detailUrl,
+      pic,
+      debug: summarizeImageCandidates($, $(".detail-box-side").first(), picSelectors),
+    });
+  }
+  const tags = $(".detail-tags .detail-tags-item").map((_, el) => cleanText($(el).text())).get().filter(Boolean);
+  const meta = parseDetailRows($);
+  const desc = cleanText($(".detail-desc").first().text() || $("meta[name='description']").attr("content") || "");
+  const remarks = meta["备注"] || meta["状态"] || "";
+  const vod_play_sources = parseDetailSources($);
+  return {
+    vod_id: String(detailUrl || ""),
+    vod_name: title,
+    vod_pic: pic,
+    vod_pic_headers: { ...PIC_HEADERS },
+    vod_remarks: remarks,
+    vod_year: meta["首映"] ? String(meta["首映"]).slice(0, 4) : tags.find((tag) => /^\d{4}$/.test(tag)) || "",
+    vod_area: tags.find((tag) => /中国|美国|日本|韩国|英国|香港|台湾|泰国|法国|德国|印度/.test(tag)) || "",
+    type_name: tags.filter((tag) => !/^\d{4}$/.test(tag) && !/中国|美国|日本|韩国|英国|香港|台湾|泰国|法国|德国|印度/.test(tag)).join(","),
+    vod_actor: meta["演员"] || "",
+    vod_director: meta["导演"] || "",
+    vod_lang: meta["语言"] || "",
+    vod_content: desc,
+    vod_play_sources,
+  };
+}
+
+function decodeUnicodeEscapes(value) {
+  return String(value || "").replace(/\\u([0-9a-fA-F]{4})/g, (_, hex) => String.fromCharCode(parseInt(hex, 16)));
+}
+
+function resolvePlayUrl(rawUrl) {
+  let playUrl = decodeUnicodeEscapes(String(rawUrl || "")).replace(/\\\//g, "/").replace(/\\/g, "").trim();
+  if (!playUrl) return "";
+  if (/^https?:\/\//i.test(playUrl)) return playUrl;
+  if (playUrl.startsWith("//")) return `https:${playUrl}`;
+  return absUrl(playUrl);
+}
+
+function extractPlaySource(html) {
+  const text = String(html || "");
+  const match = text.match(/const\s+playSource\s*=\s*\{([\s\S]*?)\};/i);
+  if (!match) return { url: "", type: "" };
+  const body = decodeUnicodeEscapes(match[1]);
+  const urlMatch = body.match(/['"]src['"]\s*:\s*['"]([^'"]+)['"]/i);
+  const typeMatch = body.match(/['"]type['"]\s*:\s*['"]([^'"]+)['"]/i);
+  return {
+    url: resolvePlayUrl(urlMatch?.[1] || ""),
+    type: decodeUnicodeEscapes(typeMatch?.[1] || ""),
+  };
+}
+
+async function resolvePlayPage(playPageUrl, referer) {
+  const html = await requestText(playPageUrl, { referer });
+  const source = extractPlaySource(html);
+  if (source.url) return source;
+  return { url: "", type: "" };
+}
+
+function buildShowUrl(tid, ext = {}) {
+  const type = encodeSegment(ext.type || "");
+  const area = encodeSegment(ext.area || "");
+  const lang = encodeSegment(ext.lang || "");
+  const year = encodeSegment(ext.year || "");
+  const by = encodeSegment(ext.by || "3");
+  const page = Math.max(1, Number(ext.page || 1));
+  return `${BASE_URL}/show/${encodeURIComponent(String(tid || "1"))}-${type}-${area}-${lang}-${year}-${by}-${page}.html`;
+}
+
+async function home() {
+  try {
+    const html = await getCachedText("dushe03:home", HOME_CACHE_TTL, () => requestText(`${BASE_URL}/`));
+    let imageDebugLogged = 0;
+    const list = parseModuleList(html, {
+      logImageDebug: ({ title, href, pic, debug }) => {
+        if (imageDebugLogged >= 2) return;
+        imageDebugLogged += 1;
+        OmniBox.log("info", `[毒舌03][image][home] title=${title} href=${href} picked=${pic} abs=${absUrl(pic)} headers=${JSON.stringify(PIC_HEADERS)} debug=${JSON.stringify(debug)}`);
+      },
+    }).slice(0, 24);
+    await OmniBox.log("info", `[毒舌03][home] count=${list.length}`);
+    return { class: CLASS_LIST, filters: FILTERS, list };
+  } catch (e) {
+    await OmniBox.log("error", `[毒舌03][home] failed: ${e.message || e}`);
+    return { class: CLASS_LIST, filters: FILTERS, list: [] };
+  }
+}
+
+async function category(params = {}) {
+  try {
+    const tid = String(params.type_id || params.categoryId || params.tid || "1");
+    const page = Math.max(1, Number(params.page || params.pg || 1));
+    const extend = params.filters || params.extend || params.ext || {};
+    const hasFilter = ["type", "area", "lang", "year"].some((key) => String(extend[key] || "").length > 0) || String(extend.by || "") !== "";
+    const url = hasFilter || page > 1
+      ? buildShowUrl(tid, { ...extend, by: extend.by || "3", page })
+      : `${BASE_URL}${CATEGORY_SHOW_PATH[tid] || `/channel/${encodeURIComponent(tid)}.html`}`;
+    const html = await getCachedText(`dushe03:category:${tid}:${JSON.stringify(extend)}:${page}`, CATEGORY_CACHE_TTL, () => requestText(url));
+    let imageDebugLogged = 0;
+    const list = parseModuleList(html, {
+      logImageDebug: ({ title, href, pic, debug }) => {
+        if (imageDebugLogged >= 2) return;
+        imageDebugLogged += 1;
+        OmniBox.log("info", `[毒舌03][image][category] title=${title} href=${href} picked=${pic} abs=${absUrl(pic)} headers=${JSON.stringify(PIC_HEADERS)} debug=${JSON.stringify(debug)}`);
+      },
+    });
+    const pagecount = parsePageCount(html, page);
+    await OmniBox.log("info", `[毒舌03][category] tid=${tid} page=${page} filters=${JSON.stringify(extend)} url=${url.replace(BASE_URL, "")} count=${list.length} pagecount=${pagecount}`);
+    return {
+      page,
+      pagecount,
+      limit: list.length,
+      total: list.length,
+      filters: FILTERS[tid] || [],
+      list,
+    };
+  } catch (e) {
+    await OmniBox.log("error", `[毒舌03][category] failed: ${e.message || e}`);
+    return {
+      page: Number(params.page || params.pg || 1) || 1,
+      pagecount: 1,
+      limit: 0,
+      total: 0,
+      filters: FILTERS[String(params.type_id || params.categoryId || params.tid || "1")] || [],
+      list: [],
+    };
+  }
+}
+
+async function detail(params = {}) {
+  try {
+    const vodId = absUrl(params.vod_id || params.videoId || params.id || "");
+    if (!vodId) return { list: [] };
+    const html = await getCachedText(`dushe03:detail:${vodId}`, DETAIL_CACHE_TTL, () => requestText(vodId));
+    const vod = parseDetail(html, vodId, {
+      logImageDebug: ({ title, href, pic, debug }) => {
+        OmniBox.log("info", `[毒舌03][image][detail] title=${title} href=${href} picked=${pic} abs=${absUrl(pic)} headers=${JSON.stringify(PIC_HEADERS)} debug=${JSON.stringify(debug)}`);
+      },
+    });
+    await OmniBox.log("info", `[毒舌03][detail] vod=${vod.vod_name || vodId} sources=${vod.vod_play_sources?.length || 0}`);
+    return { list: [vod] };
+  } catch (e) {
+    await OmniBox.log("error", `[毒舌03][detail] failed: ${e.message || e}`);
+    return { list: [] };
+  }
+}
+
+async function search(params = {}) {
+  try {
+    const wd = String(params.wd || params.keyword || "").trim();
+    const page = Math.max(1, Number(params.page || 1));
+    if (!wd) return { page, pagecount: 1, limit: 0, total: 0, list: [] };
+    const homeHtml = await getCachedText("dushe03:home", HOME_CACHE_TTL, () => requestText(`${BASE_URL}/`));
+    const token = encodeURIComponent(extractSearchToken(homeHtml) || encodeSearchToken(wd));
+    const url = page > 1
+      ? `${BASE_URL}/search?k=${encodeURIComponent(wd)}&t=${token}&page=${page}`
+      : `${BASE_URL}/search?k=${encodeURIComponent(wd)}&t=${token}`;
+    const html = await getCachedText(`dushe03:search:${wd}:${page}`, SEARCH_CACHE_TTL, () => requestText(url, { referer: `${BASE_URL}/` }));
+    const list = parseSearchList(html);
+    const pagecount = parsePageCount(html, page);
+    await OmniBox.log("info", `[毒舌03][search] wd=${wd} page=${page} count=${list.length}`);
+    return {
+      page,
+      pagecount,
+      limit: list.length,
+      total: list.length,
+      list,
+    };
+  } catch (e) {
+    await OmniBox.log("error", `[毒舌03][search] failed: ${e.message || e}`);
+    return {
+      page: Number(params.page || 1) || 1,
+      pagecount: 1,
+      limit: 0,
+      total: 0,
+      list: [],
+    };
+  }
+}
+
+async function play(params = {}) {
+  try {
+    const playId = String(params.playId || params.id || "").trim();
+    if (!playId) return { parse: 0, url: "", urls: [], header: {} };
+
+    if (/\.(m3u8|mp4)(\?|#|$)/i.test(playId)) {
+      const url = resolvePlayUrl(playId);
+      return { parse: 0, url, urls: [{ name: "播放", url }], header: {} };
+    }
+
+    const cacheKey = `dushe03:play:${playId}`;
+    const resolved = await getCachedText(cacheKey, PLAY_CACHE_TTL, async () => {
+      const absolutePlayId = absUrl(playId);
+      if (/\/play\//.test(absolutePlayId)) {
+        const source = await resolvePlayPage(absolutePlayId, `${BASE_URL}/`);
+        return JSON.stringify(source || {});
+      }
+      if (/\/detail\//.test(absolutePlayId)) {
+        const detailHtml = await requestText(absolutePlayId);
+        const vod = parseDetail(detailHtml, absolutePlayId);
+        const first = vod?.vod_play_sources?.[0]?.episodes?.[0]?.playId || "";
+        if (first && first !== absolutePlayId) {
+          if (/\.(m3u8|mp4)(\?|#|$)/i.test(first)) return JSON.stringify({ url: resolvePlayUrl(first), type: "" });
+          if (/\/play\//.test(first)) return JSON.stringify(await resolvePlayPage(first, absolutePlayId));
+          return JSON.stringify({ url: first, type: "" });
+        }
+      }
+      return JSON.stringify({ url: "", type: "" });
+    });
+
+    const parsed = (() => {
+      try {
+        return JSON.parse(String(resolved || "{}"));
+      } catch (_) {
+        return { url: String(resolved || "") };
+      }
+    })();
+    if (parsed?.url) {
+      const url = resolvePlayUrl(parsed.url);
+      await OmniBox.log("info", `[毒舌03][play] parse=0 type=${parsed.type || "unknown"} url=${url}`);
+      return { parse: 0, url, urls: [{ name: "播放", url }], header: {} };
+    }
+
+    const fallback = absUrl(playId);
+    await OmniBox.log("warn", `[毒舌03][play] fallback parse=1 url=${fallback}`);
+    return { parse: 1, url: fallback, urls: [{ name: "播放", url: fallback }], header: {} };
+  } catch (e) {
+    await OmniBox.log("error", `[毒舌03][play] failed: ${e.message || e}`);
+    return { parse: 0, url: "", urls: [], header: {} };
+  }
+}


### PR DESCRIPTION
## 变更说明
- 修复 `category()` 未读取 `filters` 导致筛选始终不生效的问题
- 补齐 `encodeSegment()`，避免筛选时报 `encodeSegment is not defined`
- 优化封面提取逻辑，跳过占位图并补充首页/分类/详情图片调试日志
- 将 `/vod1/...` 图片资源切到正确的 `https://vres.bavdxfg.cn` 静态域
- 为列表、搜索、详情补充 `vod_pic_headers`

## 验证
- `node --check 影视/采集/毒舌03.js`
- 根据 OmniBox 调试日志确认分类请求已命中不同 `/show/...` 路由
- 根据用户反馈确认图片静态域应为 `https://vres.bavdxfg.cn`
