### PR TITLE
fix: 修复七味分组分享名缓存 key 过长

### DIFF
--- a/影视/网盘/七味分组.js
+++ b/影视/网盘/七味分组.js
@@ -2,7 +2,7 @@
 // @author https://github.com/hjdhnx/drpy-node/blob/main/spider/js/%E4%B8%83%E5%91%B3%5B%E4%BC%98%5D.js
 // @description 刮削：支持，弹幕：支持，嗅探：支持，仅保留七味网盘线路的分组版本
 // @dependencies: axios, cheerio
-// @version      1.4.0
+// @version      1.4.1
 // @downloadURL https://gh-proxy.org/https://github.com/Silent1566/OmniBox-Spider/raw/refs/heads/main/影视/网盘/七味分组.js
 
 const axios = require("axios");
@@ -1419,7 +1419,27 @@ function buildPanGroupDirectoryCacheKey(videoId = "") {
 }
 
 function buildShareNameCacheKey(shareURL = "") {
-    return buildCacheKey(`qiwei-group:shareName:${QIWEI_PAN_CACHE_VERSION}`, normalizeShareUrl(shareURL));
+    const normalizedShareURL = normalizeShareUrl(shareURL);
+    const driveType = normalizeDriveType(inferDriveTypeFromShareURL(normalizedShareURL) || "unknown");
+    let compactValue = normalizedShareURL;
+
+    if (driveType === "baidu") {
+        try {
+            const parsed = new URL(normalizedShareURL);
+            const pwd = parsed.searchParams.get("pwd") || "";
+            const path = String(parsed.pathname || "").trim();
+            compactValue = `baidu:${path}${pwd ? `?pwd=${pwd}` : ""}`;
+        } catch {
+            compactValue = normalizedShareURL;
+        }
+    } else {
+        const shareId = extractPanShareId(normalizedShareURL);
+        if (shareId) {
+            compactValue = `${driveType}:${shareId}`;
+        }
+    }
+
+    return buildCacheKey(`qiwei-group:shareName:${QIWEI_PAN_CACHE_VERSION}`, compactValue);
 }
 
 function encodePanFolderMeta(meta = {}) {


### PR DESCRIPTION
## 变更说明
- 修复七味分组分享名缓存 key 过长导致的写入失败告警
- 分享名缓存优先使用网盘类型与 shareId 生成更短、更稳定的 key
- 百度分享保留路径与提取码，避免不同分享链接误撞
- 保留原有 `buildCacheKey()` 的 sha1 兜底逻辑

## 验证
- `node --check '影视/网盘/七味分组.js'`
