### PR TITLE
优化 LIBVIO 缓存与播放链路

### DIFF
--- a/影视/采集/LIBVIO.js
+++ b/影视/采集/LIBVIO.js
@@ -1,12 +1,13 @@
 // @name LIBVIO
 // @author 梦
-// @description 刮削：未接入，弹幕：未接入，嗅探：不需要（直链优先，支持网盘线路展开）
+// @description 刮削：已接入，弹幕：已接入，播放记录：已接入，嗅探：不需要（直链优先，支持网盘线路展开）
 // @dependencies
-// @version 1.3.8
+// @version 1.4.7
 // @downloadURL https://gh-proxy.org/https://github.com/Silent1566/OmniBox-Spider/raw/refs/heads/main/影视/采集/LIBVIO.js
 
 const http = require("http");
 const https = require("https");
+const crypto = require("crypto");
 const { URL } = require("url");
 const OmniBox = require("omnibox_sdk");
 const runner = require("spider_runner");
@@ -21,6 +22,13 @@ const UA = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML,
 let ACTIVE_HOST = HOST_CANDIDATES[0];
 
 const DEFAULT_PAGE_SIZE = 12;
+const HOME_CACHE_TTL = 60 * 15;
+const CATEGORY_CACHE_TTL = 60 * 10;
+const SEARCH_CACHE_TTL = 60 * 10;
+const DETAIL_CACHE_TTL = 60 * 20;
+const FILTER_CACHE_TTL = 60 * 20;
+const PAN_SHARE_CACHE_TTL = 60 * 60;
+const PLAY_CACHE_TTL = 60 * 3;
 const DRIVE_TYPE_CONFIG = (process.env.DRIVE_TYPE_CONFIG || "quark;uc").split(";").map((t) => t.trim().toLowerCase()).filter(Boolean);
 const SOURCE_NAMES_CONFIG = (process.env.SOURCE_NAMES_CONFIG || "本地代理;服务端代理;直连").split(";").map((s) => s.trim()).filter(Boolean);
 const DRIVE_ORDER = (process.env.DRIVE_ORDER || "baidu;tianyi;quark;uc;115;xunlei;ali;123pan").split(";").map((s) => s.trim().toLowerCase()).filter(Boolean);
@@ -174,7 +182,51 @@ async function requestText(url, options = {}) {
     throw lastError || new Error(`请求失败: ${raw}`);
 }
 
+function md5Short(input = "") {
+    return crypto.createHash("md5").update(String(input || "")).digest("hex").slice(0, 16);
+}
 
+function buildCacheKey(prefix = "", ...parts) {
+    const rawParts = parts
+        .flat()
+        .map((item) => item === undefined || item === null ? "" : String(item))
+        .filter((item) => item !== "");
+    const raw = rawParts.join("|");
+    const short = raw ? md5Short(raw) : "empty";
+    return `${prefix}:${short}`;
+}
+
+async function getCachedText(cacheKey, ttl, producer) {
+    try {
+        const cached = await OmniBox.getCache(cacheKey);
+        if (cached) return String(cached);
+    } catch (error) {
+        logInfo("读取文本缓存失败", { cacheKey, error: error.message });
+    }
+    const text = String(await producer());
+    try {
+        await OmniBox.setCache(cacheKey, text, ttl);
+    } catch (error) {
+        logInfo("写入文本缓存失败", { cacheKey, error: error.message });
+    }
+    return text;
+}
+
+async function getCachedJson(cacheKey, ttl, producer) {
+    try {
+        const cached = await OmniBox.getCache(cacheKey);
+        if (cached) return JSON.parse(String(cached));
+    } catch (error) {
+        logInfo("读取 JSON 缓存失败", { cacheKey, error: error.message });
+    }
+    const value = await producer();
+    try {
+        await OmniBox.setCache(cacheKey, JSON.stringify(value), ttl);
+    } catch (error) {
+        logInfo("写入 JSON 缓存失败", { cacheKey, error: error.message });
+    }
+    return value;
+}
 
 module.exports = { home, category, detail, search, play };
 runner.run(module.exports);
@@ -210,6 +262,84 @@ function stripTags(text = "") {
         .replace(/&quot;/g, '"')
         .replace(/\s+/g, " ")
         .trim();
+}
+
+function normalizeText(text = "") {
+    return stripTags(String(text || ""))
+        .normalize("NFKC")
+        .replace(/[【】\[\]()（）]/g, " ")
+        .replace(/[·•・]/g, " ")
+        .replace(/[：:]/g, " ")
+        .replace(/\s+/g, " ")
+        .trim();
+}
+
+function buildMappingPreview(mappings = [], limit = 3) {
+    return ensureArray(mappings)
+        .slice(0, limit)
+        .map((item) => `${item?.fileId || "<empty>"}=>${item?.episodeName || item?.name || "<empty>"}`)
+        .join(" | ");
+}
+
+function buildScrapedEpisodeName(scrapeData, mapping, fallbackName = "") {
+    const fallback = normalizeText(fallbackName || "") || String(fallbackName || "").trim() || "正片";
+    if (!mapping) return fallback;
+    const seasonNumber = mapping.seasonNumber;
+    const episodeNumber = mapping.episodeNumber;
+    const rawEpisodeName = normalizeText(mapping.episodeName || "");
+    const title = normalizeText(scrapeData?.title || "");
+    const episodeTitle = rawEpisodeName && rawEpisodeName !== title ? rawEpisodeName : "";
+
+    if (episodeNumber !== undefined && episodeNumber !== null && episodeNumber !== "") {
+        const epLabel = `第${episodeNumber}集`;
+        if (episodeTitle) {
+            return seasonNumber ? `S${seasonNumber}E${episodeNumber} ${episodeTitle}` : `${epLabel} ${episodeTitle}`;
+        }
+        return seasonNumber ? `S${seasonNumber}E${episodeNumber}` : epLabel;
+    }
+
+    if (episodeTitle) return episodeTitle;
+    return fallback;
+}
+
+function buildDanmakuFileName(vodName = "", episodeName = "") {
+    const title = normalizeText(vodName || "");
+    if (!title) return "";
+    const episode = normalizeText(episodeName || "");
+    return episode ? `${title} ${episode}` : title;
+}
+
+function buildHistoryEpisode(playId, episodeNumber, episodeName) {
+    if (episodeNumber !== undefined && episodeNumber !== null && episodeNumber !== "") {
+        return `${playId || ""}@@${episodeNumber}`;
+    }
+    return `${playId || ""}@@${normalizeText(episodeName || "正片") || "正片"}`;
+}
+
+function sortEpisodesByMeta(episodes = []) {
+    if (!Array.isArray(episodes) || episodes.length <= 1) return episodes;
+    const items = episodes.map((ep, index) => {
+        const meta = decodePlayId(String(ep?.playId || "").split("|||")[1] || "");
+        const season = Number(meta?.s);
+        const episode = Number(meta?.n);
+        return {
+            ep,
+            index,
+            hasSeason: Number.isFinite(season) && season > 0,
+            hasEpisode: Number.isFinite(episode) && episode > 0,
+            season: Number.isFinite(season) ? season : Number.MAX_SAFE_INTEGER,
+            episode: Number.isFinite(episode) ? episode : Number.MAX_SAFE_INTEGER,
+        };
+    });
+    const hasSortable = items.some((item) => item.hasEpisode);
+    if (!hasSortable) return episodes;
+    items.sort((a, b) => {
+        if (a.hasEpisode !== b.hasEpisode) return a.hasEpisode ? -1 : 1;
+        if (a.season !== b.season) return a.season - b.season;
+        if (a.episode !== b.episode) return a.episode - b.episode;
+        return a.index - b.index;
+    });
+    return items.map((item) => item.ep);
 }
 
 function fixUrl(url = "") {
@@ -329,7 +459,7 @@ function buildYearOptions() {
 
 function getCategoryBasePath(categoryId, page = 1) {
     const cid = encodeURIComponent(String(categoryId));
-    return page > 1 ? `/show/${cid}--------${page}---.html` : `/type/${cid}.html`;
+    return page > 1 ? `/type/${cid}-${page}.html` : `/type/${cid}.html`;
 }
 
 function parseFilterGroups(html = "") {
@@ -403,17 +533,20 @@ function resolveFilterHref(groups, key, value) {
 }
 
 async function resolveCategoryUrl(categoryId, page, filters = {}) {
-    let currentUrl = fixUrl(getCategoryBasePath(categoryId, page));
-    const order = ["genre", "area", "year", "lang", "sort"];
+    const filterKey = buildCacheKey("libvio:category-filter-url", categoryId, page, JSON.stringify(filters || {}));
+    return await getCachedText(filterKey, FILTER_CACHE_TTL, async () => {
+        let currentUrl = fixUrl(getCategoryBasePath(categoryId, page));
+        const order = ["genre", "area", "year", "lang", "sort"];
 
-    for (const key of order) {
-        const html = await fetchHtml(currentUrl);
-        const groups = parseFilterGroups(html);
-        const targetHref = resolveFilterHref(groups, key, filters[key]);
-        if (targetHref) currentUrl = targetHref;
-    }
+        for (const key of order) {
+            const html = await fetchHtml(currentUrl, { ttl: FILTER_CACHE_TTL });
+            const groups = parseFilterGroups(html);
+            const targetHref = resolveFilterHref(groups, key, filters[key]);
+            if (targetHref) currentUrl = targetHref;
+        }
 
-    return currentUrl;
+        return currentUrl;
+    });
 }
 
 function buildSearchPath(keyword, page = 1) {
@@ -421,8 +554,13 @@ function buildSearchPath(keyword, page = 1) {
     return `/search/------------${pageSeg}---.html?wd=${encodeURIComponent(keyword)}`;
 }
 
-async function fetchHtml(url) {
-    return String(await requestText(url));
+async function fetchHtml(url, options = {}) {
+    const ttl = Number(options?.ttl || 0);
+    if (ttl > 0) {
+        const cacheKey = buildCacheKey("libvio:html", url);
+        return await getCachedText(cacheKey, ttl, async () => String(await requestText(url, options)));
+    }
+    return String(await requestText(url, options));
 }
 
 function parseVodList(html = "") {
@@ -521,12 +659,15 @@ async function getAllVideoFiles(shareURL, files) {
 async function loadPanFiles(shareURL) {
     if (!shareURL) return null;
     if (panShareCache.has(shareURL)) return panShareCache.get(shareURL);
+    const cacheKey = buildCacheKey("libvio:pan-share", shareURL);
     try {
-        const driveInfo = await OmniBox.getDriveInfoByShareURL(shareURL);
-        const fileList = await OmniBox.getDriveFileList(shareURL, "0");
-        const files = Array.isArray(fileList?.files) ? fileList.files : [];
-        const videos = await getAllVideoFiles(shareURL, files);
-        const result = { driveInfo, videos };
+        const result = await getCachedJson(cacheKey, PAN_SHARE_CACHE_TTL, async () => {
+            const driveInfo = await OmniBox.getDriveInfoByShareURL(shareURL);
+            const fileList = await OmniBox.getDriveFileList(shareURL, "0");
+            const files = Array.isArray(fileList?.files) ? fileList.files : [];
+            const videos = await getAllVideoFiles(shareURL, files);
+            return { driveInfo, videos };
+        });
         panShareCache.set(shareURL, result);
         return result;
     } catch (error) {
@@ -597,7 +738,11 @@ function expandPanSourcesWithRoutes(playSources = [], from = "web") {
                 name: `${source.name}-${routeName}`,
                 episodes: (source.episodes || []).map((ep) => {
                     const decoded = decodeCombinedPlayId(ep.playId);
-                    const meta = { ...(decoded.meta || {}), routeType: routeName, flag: `${source.name}-${routeName}` };
+                    const baseMeta = decoded.meta || {};
+                    const fileId = String(baseMeta.fileId || baseMeta.fid || "").trim();
+                    const shareUrl = String(baseMeta.shareUrl || baseMeta.shareURL || "").trim();
+                    const fid = shareUrl && fileId ? `${shareUrl}|${fileId}` : fileId;
+                    const meta = { ...(decoded.meta || {}), routeType: routeName, flag: `${source.name}-${routeName}`, fid: fid || baseMeta.fid || "" };
                     return {
                         name: ep.name,
                         playId: `${decoded.main}|||${encodePlayId(meta)}`
@@ -673,7 +818,7 @@ function emptyPage(page = 1) {
 async function home(params, context) {
     try {
         logInfo("home 进入", { params, host: getCurrentHost(), from: context?.from || "web" });
-        const html = await fetchHtml("/");
+        const html = await fetchHtml("/", { ttl: HOME_CACHE_TTL });
         const list = parseVodList(html).slice(0, 24);
         const classes = CLASS_LIST.map((item) => ({ ...item }));
         const filters = {};
@@ -695,7 +840,7 @@ async function category(params, context) {
     try {
         const finalUrl = await resolveCategoryUrl(categoryId, page, filters);
         logInfo("category 请求", { categoryId, page, filters, host: getCurrentHost(), path: finalUrl.replace(getCurrentHost(), ""), from: context?.from || "web" });
-        const html = await fetchHtml(finalUrl);
+        const html = await fetchHtml(finalUrl, { ttl: CATEGORY_CACHE_TTL });
         const list = parseVodList(html);
         const hasNext = html.includes(`>${page + 1}<`) || html.includes(`-${page + 1}---`) || html.includes(`下一页`);
         const pagecount = list.length === DEFAULT_PAGE_SIZE && hasNext ? page + 1 : (page > 1 || list.length ? page : 0);
@@ -719,7 +864,7 @@ async function detail(params, context) {
     if (!videoId) return { list: [] };
     try {
         logInfo("detail 请求", { videoId, host: getCurrentHost(), from: context?.from || "web" });
-        const html = await fetchHtml(videoId);
+        const html = await fetchHtml(videoId, { ttl: DETAIL_CACHE_TTL });
         const name = stripTags(html.match(/<h1[^>]*>([\s\S]*?)<\/h1>/)?.[1] || "");
         const poster = fixUrl(html.match(/class="lazyload"[^>]*data-original="([^"]+)"/)?.[1] || html.match(/data-original="([^"]+)"/)?.[1] || "");
         const intro = stripTags(html.match(/<span class="detail-content"[^>]*>([\s\S]*?)<\/span>/)?.[1] || "");
@@ -733,20 +878,34 @@ async function detail(params, context) {
         const director = metaItems.find((item) => item.startsWith("导演："))?.replace(/^导演：/, "") || "";
 
         const sourceMatches = [...html.matchAll(/<div class="playlist-panel">([\s\S]*?)<\/ul>/g)];
-        const collectSources = sourceMatches.map((matched) => {
+        const collectSources = sourceMatches.map((matched, sourceIndex) => {
             const block = matched[1];
             const sourceName = stripTags(block.match(/<h3>([\s\S]*?)<\/h3>/)?.[1] || "播放");
-            const episodes = [...block.matchAll(/href="([^"]*\/play\/[^\"]+\.html)"[^>]*>([\s\S]*?)<\/a>/g)].map((item) => ({
-                name: stripTags(item[2]),
-                playId: encodePlayId({
+            const episodes = [...block.matchAll(/href="([^"]*\/play\/[^\"]+\.html)"[^>]*>([\s\S]*?)<\/a>/g)].map((item, episodeIndex) => {
+                const episodeName = stripTags(item[2]);
+                const playUrl = fixUrl(item[1]);
+                const fid = `${videoId}#${sourceIndex}#${episodeIndex}`;
+                const meta = {
                     mode: "collect",
-                    url: fixUrl(item[1]),
+                    url: playUrl,
                     flag: sourceName,
-                    name: stripTags(item[2])
-                })
-            }));
+                    name: episodeName,
+                    v: name,
+                    e: episodeName,
+                    sid: videoId,
+                    fid,
+                    t: sourceName,
+                    i: episodeIndex,
+                };
+                return {
+                    name: episodeName,
+                    playId: `${playUrl}|||${encodePlayId(meta)}`,
+                    _fid: fid,
+                    _rawName: episodeName,
+                };
+            });
             return { name: sourceName, episodes };
-        }).filter((item) => item.episodes.length);
+        }).filter((item) => item.episodes.length && !/视频下载|网盘|夸克|uc|百度|阿里|迅雷|115|123pan/i.test(item.name || ""));
 
         const netdiskPanels = splitNetdiskPanels(html);
         const netdiskSources = [];
@@ -785,10 +944,64 @@ async function detail(params, context) {
 
         const sortedNetdiskSources = sortPlaySourcesByDriveOrder(netdiskSources);
         const expandedNetdiskSources = expandPanSourcesWithRoutes(sortedNetdiskSources, context?.from || "web");
-        const vod_play_sources = [...collectSources, ...expandedNetdiskSources];
-
-        logInfo("detail 完成", { videoId, sourceCount: vod_play_sources.length, episodeCount: vod_play_sources.reduce((n, item) => n + item.episodes.length, 0) });
-        return {
+        const normalizedCollectSources = collectSources.map((source) => ({
+            name: source.name,
+            episodes: (source.episodes || []).map((ep) => ({ name: ep.name, playId: ep.playId }))
+        }));
+        const vod_play_sources = [...normalizedCollectSources, ...expandedNetdiskSources];
+        for (const source of vod_play_sources) {
+            for (const ep of source.episodes || []) {
+                const decoded = decodeCombinedPlayId(ep.playId || "");
+                const meta = decoded.meta || {};
+                if (!meta.fid) {
+                    const fileId = String(meta.fileId || "").trim();
+                    const shareUrl = String(meta.shareUrl || meta.shareURL || "").trim();
+                    if (shareUrl && fileId) {
+                        meta.fid = `${shareUrl}|${fileId}`;
+                        ep.playId = `${decoded.main}|||${encodePlayId(meta)}`;
+                    }
+                }
+            }
+        }
+        const scrapeSourceHints = [];
+        const scrapeSourceBuckets = [];
+        for (const source of collectSources) {
+            if (Array.isArray(source?.episodes) && source.episodes.length) {
+                scrapeSourceBuckets.push({
+                    name: source.name,
+                    episodes: source.episodes.map((ep) => ({ ...ep, _scrapeSourceType: "collect" }))
+                });
+                scrapeSourceHints.push(`${source.name || "采集"}:${source.episodes.length}`);
+            }
+        }
+        for (const source of netdiskSources) {
+            if (Array.isArray(source?.episodes) && source.episodes.length) {
+                scrapeSourceBuckets.push({
+                    name: source.name,
+                    episodes: source.episodes.map((ep, episodeIndex) => {
+                        const meta = decodeCombinedPlayId(ep.playId || "")?.meta || {};
+                        const shareUrl = String(meta.shareUrl || meta.shareURL || "").trim();
+                        const fileId = String(meta.fileId || meta.fid || "").trim();
+                        const fid = shareUrl && fileId ? `${shareUrl}|${fileId}` : (fileId || ep.playId);
+                        return {
+                            ...ep,
+                            _fid: fid,
+                            _rawName: ep.name || "正片",
+                            _scrapeSourceType: "pan",
+                            _scrapeMeta: {
+                                ...meta,
+                                fid,
+                                sid: String(meta.sid || meta.vodId || videoId || ""),
+                                i: Number.isFinite(Number(meta.i)) ? Number(meta.i) : episodeIndex,
+                            }
+                        };
+                    })
+                });
+                scrapeSourceHints.push(`${source.name || "网盘"}:${source.episodes.length}`);
+            }
+        }
+        logInfo("detail 线路统计", { videoId, collectSourceCount: collectSources.length, netdiskSourceCount: netdiskSources.length, scrapeSourceCount: scrapeSourceBuckets.length, scrapeSources: scrapeSourceHints.join(" | ") });
+        const result = {
             list: [{
                 vod_id: videoId,
                 vod_name: name,
@@ -802,8 +1015,109 @@ async function detail(params, context) {
                 vod_douban_score: score.replace(/分$/, ""),
                 vod_remarks: stripTags(remarks),
                 vod_play_sources
-            }]
+            }],
+            _play_sources_for_scrape: scrapeSourceBuckets,
         };
+        const vod = result.list?.[0];
+        const scrapePlaySources = Array.isArray(result._play_sources_for_scrape) ? result._play_sources_for_scrape : vod?.vod_play_sources || [];
+        const canProcessScraping = typeof OmniBox.processScraping === "function";
+        const canGetScrapeMetadata = typeof OmniBox.getScrapeMetadata === "function";
+        if (!vod) {
+            logInfo("detail 跳过刮削", { videoId, reason: "vod 为空" });
+        } else if (!Array.isArray(scrapePlaySources) || scrapePlaySources.length === 0) {
+            logInfo("detail 无站内采集线路，跳过刮削", { videoId, sourceCount: Array.isArray(scrapePlaySources) ? scrapePlaySources.length : -1 });
+        } else if (!canProcessScraping || !canGetScrapeMetadata) {
+            logInfo("detail 宿主未提供刮削能力，跳过刮削", { videoId, hasProcessScraping: canProcessScraping, hasGetScrapeMetadata: canGetScrapeMetadata });
+        } else {
+            let scrapeData = null;
+            let videoMappings = [];
+            const scrapeCandidates = [];
+            for (const source of scrapePlaySources) {
+                for (const ep of source.episodes || []) {
+                    const fid = ep._fid || decodePlayId(String(ep.playId || "").split("|||")[1] || "")?.fid || ep.playId;
+                    if (!fid) continue;
+                    scrapeCandidates.push({
+                        fid,
+                        file_id: fid,
+                        file_name: ep._rawName || ep.name || "正片",
+                        name: ep._rawName || ep.name || "正片",
+                        format_type: "video",
+                    });
+                }
+            }
+            logInfo("detail 刮削候选", { videoId, count: scrapeCandidates.length, preview: scrapeCandidates.slice(0, 3).map((item) => `${item.fid}=>${item.file_name}`).join(" | ") });
+            if (scrapeCandidates.length === 0) {
+                logInfo("detail 刮削候选为空，跳过刮削", { videoId, sourceNames: scrapePlaySources.map((item) => item?.name || "") });
+            }
+            if (scrapeCandidates.length > 0) {
+                try {
+                    const scrapeKeyword = normalizeText(vod.vod_name || name || "");
+                    const scrapingResult = await OmniBox.processScraping(videoId, scrapeKeyword, scrapeKeyword, scrapeCandidates);
+                    logInfo("detail 刮削完成", { videoId, keyword: scrapeKeyword, result: JSON.stringify(scrapingResult || {}).slice(0, 200) });
+                    const metadata = await OmniBox.getScrapeMetadata(videoId);
+                    scrapeData = metadata?.scrapeData || null;
+                    videoMappings = Array.isArray(metadata?.videoMappings) ? metadata.videoMappings : [];
+                    logInfo("detail 刮削元数据", {
+                        videoId,
+                        hasScrapeData: !!scrapeData,
+                        mappings: videoMappings.length,
+                        scrapeType: metadata?.scrapeType || "",
+                        mappingPreview: buildMappingPreview(videoMappings),
+                        candidatePreview: scrapeCandidates.slice(0, 3).map((item) => item.file_id || item.fid || "<empty>").join(" | ")
+                    });
+                } catch (error) {
+                    logInfo("detail 刮削失败", { videoId, error: error.message });
+                }
+            }
+            logInfo("detail 刮削后状态", {
+                videoId,
+                hasScrapeData: !!scrapeData,
+                mappingCount: Array.isArray(videoMappings) ? videoMappings.length : 0,
+                scrapePlaySourceCount: scrapePlaySources.length,
+                vodPlaySourceCount: Array.isArray(vod?.vod_play_sources) ? vod.vod_play_sources.length : 0,
+            });
+            if (scrapeData) {
+                vod.vod_name = scrapeData.title || vod.vod_name;
+                if (scrapeData.posterPath) {
+                    vod.vod_pic = `https://image.tmdb.org/t/p/w500${scrapeData.posterPath}`;
+                }
+                if (scrapeData.overview) {
+                    vod.vod_content = scrapeData.overview;
+                }
+            }
+            for (const source of vod.vod_play_sources || []) {
+                for (const ep of source.episodes || []) {
+                    if (!String(ep.playId || "").includes("|||")) continue;
+                    const [mainPlayId, metaB64] = String(ep.playId || "").split("|||");
+                    const meta = decodePlayId(metaB64 || "");
+                    const fid = meta?.fid;
+                    if (!fid) continue;
+                    const mapping = videoMappings.find((item) => item?.fileId === fid);
+                    if (!mapping) {
+                        logInfo("detail 分集未命中刮削映射", {
+                            fid,
+                            episodeName: ep.name || "",
+                            mappingPreview: buildMappingPreview(videoMappings),
+                        });
+                        continue;
+                    }
+                    const oldName = ep.name;
+                    const newName = buildScrapedEpisodeName(scrapeData, mapping, oldName);
+                    if (newName && newName !== oldName) {
+                        ep.name = newName;
+                        logInfo("detail 应用刮削分集名", { from: oldName, to: newName, fid });
+                    }
+                    meta.e = ep.name;
+                    meta.s = mapping.seasonNumber;
+                    meta.n = mapping.episodeNumber;
+                    ep.playId = `${mainPlayId}|||${encodePlayId(meta)}`;
+                }
+                source.episodes = sortEpisodesByMeta(source.episodes || []);
+            }
+        }
+
+        logInfo("detail 完成", { videoId, sourceCount: vod_play_sources.length, episodeCount: vod_play_sources.reduce((n, item) => n + item.episodes.length, 0) });
+        return result;
     } catch (error) {
         logError("detail 失败", error);
         return { list: [] };
@@ -817,7 +1131,7 @@ async function search(params, context) {
     try {
         const path = buildSearchPath(keyword, page);
         logInfo("search 请求", { keyword, page, host: getCurrentHost(), path, quick: params?.quick ? 1 : 0, from: context?.from || "web" });
-        const html = await fetchHtml(path);
+        const html = await fetchHtml(path, { ttl: SEARCH_CACHE_TTL });
         const list = parseVodList(html);
         const pagecount = list.length === DEFAULT_PAGE_SIZE ? page + 1 : page;
         logInfo("search 完成", { keyword, page, listCount: list.length, pagecount });
@@ -852,95 +1166,251 @@ async function play(params, context) {
             const fileId = String(meta.fileId || "");
             const routeType = String(meta.routeType || "").trim() || (context?.from === "web" ? "服务端代理" : "直连");
             if (shareURL && fileId) {
-                try {
-                    const playInfo = await OmniBox.getDriveVideoPlayInfo(shareURL, fileId, routeType);
+                const playInfoPromise = OmniBox.getDriveVideoPlayInfo(shareURL, fileId, routeType);
+                const metadataPromise = (async () => {
+                    const result = {
+                        danmakuList: [],
+                        scrapeTitle: "",
+                        scrapePic: "",
+                        episodeNumber: meta?.n ?? null,
+                        episodeName: meta?.name || meta?.e || "",
+                    };
+                    if (!meta?.fid || typeof OmniBox.getScrapeMetadata !== "function") {
+                        logInfo("play 网盘增强链路跳过", { shareURL, fid: meta?.fid || "" });
+                        return result;
+                    }
+                    try {
+                        const metadata = await OmniBox.getScrapeMetadata(String(meta.sid || meta.vodId || ""));
+                        if (!metadata || !metadata.scrapeData) {
+                            logInfo("play 网盘增强链路跳过: metadata 不完整", { shareURL, vodId: meta.sid || meta.vodId || "" });
+                            return result;
+                        }
+                        result.scrapeTitle = metadata.scrapeData.title || "";
+                        if (metadata.scrapeData.posterPath) {
+                            result.scrapePic = `https://image.tmdb.org/t/p/w500${metadata.scrapeData.posterPath}`;
+                        }
+                        const mappings = Array.isArray(metadata.videoMappings) ? metadata.videoMappings : [];
+                        const mapping = mappings.find((item) => item?.fileId === meta.fid);
+                        if (mapping) {
+                            result.episodeName = buildScrapedEpisodeName(metadata.scrapeData, mapping, result.episodeName || meta.name || "");
+                            if (mapping.episodeNumber !== undefined && mapping.episodeNumber !== null) {
+                                result.episodeNumber = mapping.episodeNumber;
+                            }
+                        }
+                        const fileName = buildDanmakuFileName(result.scrapeTitle || meta.vodName || "", result.episodeName || meta.name || "");
+                        if (fileName && typeof OmniBox.getDanmakuByFileName === "function") {
+                            const matchedDanmaku = await OmniBox.getDanmakuByFileName(fileName);
+                            if (Array.isArray(matchedDanmaku) && matchedDanmaku.length > 0) {
+                                result.danmakuList = matchedDanmaku;
+                            }
+                            logInfo("play 网盘弹幕匹配", { fileName, count: Array.isArray(matchedDanmaku) ? matchedDanmaku.length : 0 });
+                        }
+                    } catch (error) {
+                        logInfo("play 网盘增强链路失败", { shareURL, error: error.message });
+                    }
+                    return result;
+                })();
+                const [playInfoResult, metadataResult] = await Promise.allSettled([playInfoPromise, metadataPromise]);
+                if (playInfoResult.status === "fulfilled") {
+                    const playInfo = playInfoResult.value || {};
                     const urlList = Array.isArray(playInfo?.url) ? playInfo.url : [];
+                    const metadataValue = metadataResult.status === "fulfilled" ? metadataResult.value : {};
+                    const danmakuList = metadataValue?.danmakuList?.length ? metadataValue.danmakuList : (playInfo?.danmaku || []);
+                    if (meta?.fid && context?.sourceId && typeof OmniBox.addPlayHistory === "function") {
+                        const historyPayload = {
+                            vodId: String(meta.sid || meta.vodId || ""),
+                            title: metadataValue?.scrapeTitle || meta.vodName || meta.name || "LIBVIO视频",
+                            pic: metadataValue?.scrapePic || "",
+                            episode: buildHistoryEpisode(playId, metadataValue?.episodeNumber, metadataValue?.episodeName || meta.name || meta.e || ""),
+                            sourceId: context.sourceId,
+                            episodeNumber: metadataValue?.episodeNumber,
+                            episodeName: metadataValue?.episodeName || meta.name || meta.e || "",
+                        };
+                        OmniBox.addPlayHistory(historyPayload).then((added) => {
+                            OmniBox.log("info", `[LIBVIO] play 网盘播放记录${added ? "已添加" : "已存在"}: ${historyPayload.title}`);
+                        }).catch((error) => {
+                            OmniBox.log("info", `[LIBVIO] play 网盘添加播放记录失败: ${error.message}`);
+                        });
+                    }
                     return {
                         urls: urlList.map((item) => ({ name: item.name || meta.name || "播放", url: item.url })),
                         flag: shareURL,
                         header: playInfo?.header || {},
                         parse: 0,
-                        danmaku: playInfo?.danmaku || []
-                    };
-                } catch (error) {
-                    logInfo("play 网盘直取失败", { shareURL, fileId, routeType, error: error.message });
-                    return {
-                        parse: 0,
-                        flag: playFlag,
-                        urls: [{ name: meta.name || "网盘资源", url: `push://${shareURL}` }]
+                        danmaku: danmakuList,
                     };
                 }
+                logInfo("play 网盘直取失败", { shareURL, fileId, routeType, error: playInfoResult.reason?.message || String(playInfoResult.reason || "") });
+                return {
+                    parse: 0,
+                    flag: playFlag,
+                    urls: [{ name: meta.name || "网盘资源", url: `push://${shareURL}` }]
+                };
             }
         }
 
-        logInfo("play 请求", { playPageUrl, flag: playFlag, from: context?.from || "web" });
-        const html = await fetchHtml(playPageUrl);
-        const playerJson = html.match(/player_aaaa\s*=\s*(\{[\s\S]*?\})<\/script>/)?.[1];
-        if (!playerJson) {
-            logInfo("play 未找到 player_aaaa", { playPageUrl });
-            return {
-                parse: 1,
-                flag: playFlag,
-                header: {
-                    Referer: `${getCurrentHost()}/`,
-                    Origin: getCurrentHost(),
-                    "User-Agent": UA
-                },
-                urls: [{ name: meta.name || "播放", url: playPageUrl }]
-            };
-        }
-
-        const player = JSON.parse(playerJson);
-        const realUrl = buildPlayUrl(decodePlayerUrl(player.url, player.encrypt));
-        if (realUrl && isDirectMediaUrl(realUrl)) {
-            logInfo("play 直链完成", { playPageUrl, from: player.from, finalUrl: realUrl });
-            return {
-                parse: 0,
-                flag: playFlag,
-                header: {
-                    Referer: `${getCurrentHost()}/`,
-                    Origin: getCurrentHost(),
-                    "User-Agent": UA
-                },
-                urls: [{ name: meta.name || "播放", url: realUrl }]
-            };
-        }
-
-        const iframeUrl = buildProviderIframeUrl(player);
-        const sniffTarget = iframeUrl || playPageUrl;
         const sniffHeaders = {
             Referer: `${getCurrentHost()}/`,
             Origin: getCurrentHost(),
             "User-Agent": UA
         };
-        try {
-            const sniffResult = await OmniBox.sniffVideo(sniffTarget, sniffHeaders);
-            const sniffUrls = Array.isArray(sniffResult?.urls) ? sniffResult.urls.filter((item) => item?.url) : [];
-            if (!sniffUrls.length && sniffResult?.url) {
-                sniffUrls.push({ name: meta.name || "播放", url: sniffResult.url });
-            }
-            if (sniffUrls.length) {
-                logInfo("play SDK嗅探完成", { playPageUrl, from: player.from, sniffTarget, sniffCount: sniffUrls.length, first: sniffUrls[0] || null });
-                return {
-                    parse: 0,
-                    flag: playFlag,
-                    header: sniffResult?.header || sniffHeaders,
-                    urls: sniffUrls.map((item) => ({ name: item.name || meta.name || "播放", url: item.url })),
-                    danmaku: sniffResult?.danmaku || []
-                };
-            }
-            logInfo("play SDK嗅探无结果", { playPageUrl, from: player.from, sniffTarget, sniffResult: sniffResult || null });
-        } catch (sniffError) {
-            logInfo("play SDK嗅探失败", { playPageUrl, from: player.from, sniffTarget, error: sniffError.message });
-        }
+        const playInfoPromise = (async () => {
+            const cacheKey = buildCacheKey("libvio:play", playPageUrl, playFlag, context?.from || "web");
+            return await getCachedJson(cacheKey, PLAY_CACHE_TTL, async () => {
+                logInfo("play 请求", { playPageUrl, flag: playFlag, from: context?.from || "web" });
+                const html = await fetchHtml(playPageUrl, { ttl: PLAY_CACHE_TTL });
+                const playerJson = html.match(/player_aaaa\s*=\s*(\{[\s\S]*?\})<\/script>/)?.[1];
+                if (!playerJson) {
+                    logInfo("play 未找到 player_aaaa", { playPageUrl });
+                    return {
+                        parse: 1,
+                        flag: playFlag,
+                        header: sniffHeaders,
+                        urls: [{ name: meta.name || "播放", url: playPageUrl }],
+                        danmaku: []
+                    };
+                }
 
-        logInfo("play 使用嗅探兜底", { playPageUrl, from: player.from, decodedUrl: realUrl, encrypt: player.encrypt, rawUrl: player.url, iframeUrl, sniffTarget });
-        return {
-            parse: 1,
-            flag: playFlag,
-            header: sniffHeaders,
-            urls: [{ name: meta.name || "播放", url: sniffTarget }]
-        };
+                const player = JSON.parse(playerJson);
+                const realUrl = buildPlayUrl(decodePlayerUrl(player.url, player.encrypt));
+                if (realUrl && isDirectMediaUrl(realUrl)) {
+                    logInfo("play 直链完成", { playPageUrl, from: player.from, finalUrl: realUrl });
+                    return {
+                        parse: 0,
+                        flag: playFlag,
+                        header: sniffHeaders,
+                        urls: [{ name: meta.name || "播放", url: realUrl }],
+                        danmaku: []
+                    };
+                }
+
+                const iframeUrl = buildProviderIframeUrl(player);
+                const sniffTarget = iframeUrl || playPageUrl;
+                try {
+                    const sniffResult = await OmniBox.sniffVideo(sniffTarget, sniffHeaders);
+                    const sniffUrls = Array.isArray(sniffResult?.urls) ? sniffResult.urls.filter((item) => item?.url) : [];
+                    if (!sniffUrls.length && sniffResult?.url) {
+                        sniffUrls.push({ name: meta.name || "播放", url: sniffResult.url });
+                    }
+                    if (sniffUrls.length) {
+                        logInfo("play SDK嗅探完成", { playPageUrl, from: player.from, sniffTarget, sniffCount: sniffUrls.length, first: sniffUrls[0] || null });
+                        return {
+                            parse: 0,
+                            flag: playFlag,
+                            header: sniffResult?.header || sniffHeaders,
+                            urls: sniffUrls.map((item) => ({ name: item.name || meta.name || "播放", url: item.url })),
+                            danmaku: sniffResult?.danmaku || []
+                        };
+                    }
+                    logInfo("play SDK嗅探无结果", { playPageUrl, from: player.from, sniffTarget, sniffResult: sniffResult || null });
+                } catch (sniffError) {
+                    logInfo("play SDK嗅探失败", { playPageUrl, from: player.from, sniffTarget, error: sniffError.message });
+                }
+
+                logInfo("play 使用嗅探兜底", { playPageUrl, decodedUrl: realUrl, iframeUrl, sniffTarget });
+                return {
+                    parse: 1,
+                    flag: playFlag,
+                    header: sniffHeaders,
+                    urls: [{ name: meta.name || "播放", url: sniffTarget }],
+                    danmaku: []
+                };
+            });
+        })();
+
+        const metadataPromise = (async () => {
+            const result = {
+                danmakuList: [],
+                scrapeTitle: "",
+                scrapePic: "",
+                episodeNumber: meta?.n ?? null,
+                episodeName: meta?.e || meta?.name || "",
+            };
+            if (!meta?.fid || !meta?.sid || typeof OmniBox.getScrapeMetadata !== "function") {
+                logInfo("play 播放增强链路跳过", { fid: meta?.fid || "", sid: meta?.sid || "" });
+                return result;
+            }
+            try {
+                const metadata = await OmniBox.getScrapeMetadata(String(meta.sid || ""));
+                if (!metadata || !metadata.scrapeData) {
+                    logInfo("play 播放增强链路跳过: metadata 不完整", { videoId: meta.sid || "" });
+                    return result;
+                }
+                result.scrapeTitle = metadata.scrapeData.title || "";
+                if (metadata.scrapeData.posterPath) {
+                    result.scrapePic = `https://image.tmdb.org/t/p/w500${metadata.scrapeData.posterPath}`;
+                }
+                const mappings = Array.isArray(metadata.videoMappings) ? metadata.videoMappings : [];
+                logInfo("play 播放增强元数据", { videoId: meta.sid || "", mappings: mappings.length, fid: meta.fid });
+                const mapping = mappings.find((item) => item?.fileId === meta.fid);
+                if (mapping) {
+                    result.episodeName = buildScrapedEpisodeName(metadata.scrapeData, mapping, result.episodeName || meta.name || "");
+                    if (mapping.episodeNumber !== undefined && mapping.episodeNumber !== null) {
+                        result.episodeNumber = mapping.episodeNumber;
+                    }
+                } else if (mappings.length > 0) {
+                    logInfo("play 播放增强未命中 mapping", { expected: meta.fid, preview: mappings.slice(0, 2).map((item) => `${item?.fileId || "<empty>"}=>${item?.episodeName || ""}`).join(" | ") });
+                }
+                const fileName = buildDanmakuFileName(result.scrapeTitle || meta.v || "", result.episodeName || meta.name || "");
+                if (fileName && typeof OmniBox.getDanmakuByFileName === "function") {
+                    const matchedDanmaku = await OmniBox.getDanmakuByFileName(fileName);
+                    const count = Array.isArray(matchedDanmaku) ? matchedDanmaku.length : 0;
+                    logInfo("play 弹幕匹配", { fileName, count });
+                    if (count > 0) {
+                        result.danmakuList = matchedDanmaku;
+                    }
+                }
+            } catch (error) {
+                logInfo("play 读取刮削元数据失败", { error: error.message, videoId: meta.sid || "" });
+            }
+            return result;
+        })();
+
+        const [playInfoResult, metadataResult] = await Promise.allSettled([playInfoPromise, metadataPromise]);
+        if (playInfoResult.status !== "fulfilled") {
+            throw playInfoResult.reason || new Error("播放主链路失败");
+        }
+        const playResult = playInfoResult.value || { urls: [], parse: 0, header: {} };
+        let danmakuList = [];
+        let scrapeTitle = "";
+        let scrapePic = "";
+        let episodeNumber = meta?.n ?? null;
+        let episodeName = meta?.e || meta?.name || "";
+        if (metadataResult.status === "fulfilled" && metadataResult.value) {
+            danmakuList = metadataResult.value.danmakuList || [];
+            scrapeTitle = metadataResult.value.scrapeTitle || "";
+            scrapePic = metadataResult.value.scrapePic || "";
+            if (metadataResult.value.episodeNumber !== undefined && metadataResult.value.episodeNumber !== null) {
+                episodeNumber = metadataResult.value.episodeNumber;
+            }
+            episodeName = metadataResult.value.episodeName || episodeName;
+        } else if (metadataResult.status === "rejected") {
+            logInfo("play 播放增强链路失败(不影响播放)", { error: metadataResult.reason?.message || String(metadataResult.reason || "") });
+        }
+        if (danmakuList.length > 0) {
+            playResult.danmaku = danmakuList;
+        }
+        if (meta?.fid && context?.sourceId && typeof OmniBox.addPlayHistory === "function") {
+            const historyPayload = {
+                vodId: String(meta.sid || ""),
+                title: scrapeTitle || meta.v || meta.name || "LIBVIO视频",
+                pic: scrapePic || "",
+                episode: buildHistoryEpisode(playId, episodeNumber, episodeName),
+                sourceId: context.sourceId,
+                episodeNumber,
+                episodeName: episodeName || "",
+            };
+            OmniBox.addPlayHistory(historyPayload)
+                .then((added) => {
+                    OmniBox.log("info", `[LIBVIO] play 已${added ? "添加" : "跳过"}播放记录: ${historyPayload.title}`);
+                })
+                .catch((error) => {
+                    OmniBox.log("info", `[LIBVIO] play 添加播放记录失败: ${error.message}`);
+                });
+        } else {
+            logInfo("play 跳过播放记录", { sourceId: context?.sourceId || "", fid: meta?.fid || "", hasApi: typeof OmniBox.addPlayHistory === "function" });
+        }
+        return playResult;
     } catch (error) {
         logError("play 失败", error);
         return emptyPlay(flag);


### PR DESCRIPTION
## 变更说明
- 为 `LIBVIO.js` 新增统一缓存工具，缓存 key 改为哈希短 key，避免超长 key 导致宿主缓存写入失败
- 为首页、分类、搜索、详情、分类筛选结果、网盘分享文件列表补充缓存
- 为 `play()` 普通播放链路补充 3 分钟短时缓存，减少重复解析与嗅探
- 保留并复用现有刮削、弹幕、播放记录增强链路

## 验证
- `node --check '影视/采集/LIBVIO.js'`
- 本地 `git diff` 复核缓存接入位置与版本号变更
