### PR TITLE
fix: 补全 Emby 模板一剧集集数编号

### DIFF
--- a/Emby/模板一.js
+++ b/Emby/模板一.js
@@ -2,7 +2,7 @@
 // @author
 // @description 直连 Emby 接口，TVBox T4 结构输出（刮削：不支持，弹幕：不支持，嗅探：不支持）
 // @dependencies: axios
-// @version 1.0.0
+// @version 1.0.1
 // @downloadURL https://gh-proxy.org/https://github.com/Silent1566/OmniBox-Spider/raw/refs/heads/main/Emby/模板一.js
 
 /**
@@ -452,7 +452,10 @@ async function detail(params = {}) {
             const episodesData = await requestJson(`${episodesUrl}?${new URLSearchParams(episodeParams)}`, {}, header);
             const episodes = (episodesData.Items || []).map((episode) => {
               const compositePid = `${accountIndex}@${episode.Id}`;
-              const label = `${season.Name.replace(/#/g, "-").replace(/\$/g, "|").trim()}|${cleanText(episode.Name)}`;
+              const seasonLabel = season.IndexNumber ? `第${season.IndexNumber}季` : season.Name.replace(/#/g, "-").replace(/\$/g, "|").trim();
+              const episodeLabel = episode.IndexNumber ? `第${episode.IndexNumber}集` : cleanText(episode.Name);
+              const episodeName = cleanText(episode.Name);
+              const label = `${seasonLabel} ${episodeLabel}${episodeName && episodeName !== episodeLabel ? ` ${episodeName}` : ""}`.trim();
               return { name: label, playId: compositePid };
             });
 
@@ -475,10 +478,16 @@ async function detail(params = {}) {
           const itemsData = await requestJson(`${itemsUrl}?${new URLSearchParams(itemsParams)}`, {}, header);
           const episodes = (itemsData.Items || [])
             .filter((item) => !item.IsFolder)
-            .map((item) => ({
-              name: cleanText(item.Name).replace(/#/g, "-").replace(/\$/g, "|"),
-              playId: `${accountIndex}@${item.Id}`,
-            }));
+            .map((item) => {
+              const seasonLabel = item.ParentIndexNumber ? `第${item.ParentIndexNumber}季` : "";
+              const episodeLabel = item.IndexNumber ? `第${item.IndexNumber}集` : cleanText(item.Name);
+              const episodeName = cleanText(item.Name).replace(/#/g, "-").replace(/\$/g, "|");
+              const label = `${seasonLabel} ${episodeLabel}${episodeName && episodeName !== episodeLabel ? ` ${episodeName}` : ""}`.trim();
+              return {
+                name: label,
+                playId: `${accountIndex}@${item.Id}`,
+              };
+            });
 
           if (episodes.length > 0) {
             playSources.push({ name: "资源列表", episodes });


### PR DESCRIPTION
## 变更说明
- 修复 `Emby/模板一.js` 剧集详情页仅显示“季名 | 集名”、缺失集数编号的问题
- 剧集列表优先使用 `season.IndexNumber` 与 `episode.IndexNumber` 生成 `第X季 第Y集` 展示名
- 回退到子项列表的分支也同步补齐季/集编号
- 脚本版本升级到 `1.0.1`

## 验证
- `node --check Emby/模板一.js`

## 预期效果
- 详情页剧集按钮默认展示为 `第X季 第Y集 剧集名`
- 即使走子项列表 fallback，也不会再丢失集数编号
- 关闭 #170
