### PR TITLE
修复枫叶源搜索/分类（v1.2.0）：站点验证码拦截 HTML 页，改用 JSON 接口

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,35 @@
+name: Upstream Sync
+
+permissions:
+  contents: write
+
+on:
+  schedule:
+    - cron: "0 0 * * *" # every day
+  workflow_dispatch:
+
+jobs:
+  sync_latest_from_upstream:
+    name: Sync latest commits from upstream repo
+    runs-on: ubuntu-latest
+    if: ${{ github.event.repository.fork }}
+
+    steps:
+      - name: Checkout target repo
+        uses: actions/checkout@v4
+
+      - name: Sync upstream changes
+        id: sync
+        uses: aormsby/fork-sync-with-upstream-action@v3.4.3
+        with:
+          upstream_sync_repo: Silent1566/OmniBox-Spider
+          upstream_sync_branch: main
+          target_sync_branch: main
+          target_repo_token: ${{ secrets.GITHUB_TOKEN }}
+          test_mode: false
+
+      - name: Sync check
+        if: failure()
+        run: |
+          echo "[Error] Sync failed due to workflow change or merge conflict, please sync manually"
+          exit 1

--- a/影视/采集/枫叶.js
+++ b/影视/采集/枫叶.js
@@ -2,7 +2,7 @@
 // @author 梦
 // @description 影视站：支持首页、分类、详情、搜索与播放，补齐刮削、弹幕与播放记录，基于 https://www.budaichuchen.net
 // @dependencies cheerio
-// @version 1.1.1
+// @version 1.2.0
 // @downloadURL https://gh-proxy.org/https://github.com/Silent1566/OmniBox-Spider/raw/refs/heads/main/影视/采集/枫叶.js
 
 const OmniBox = require("omnibox_sdk");
@@ -478,9 +478,9 @@ async function category(params = {}) {
     const year = String(extend.year || "");
     const lang = String(extend.lang || "");
     const letter = String(extend.letter || "");
-    const url = `${BASE_URL}/cupfox-list/${categoryId}-${area}-${by}-${clazz}-${lang}-${letter}---${page}---${year}.html`;
-    const html = await getCachedText(`fengye:category:${categoryId}:${page}:${area}:${by}:${clazz}:${year}:${lang}:${letter}`, LIST_CACHE_TTL, () => requestText(url));
-    const list = parseHomeList(html);
+    const url = `${BASE_URL}/index.php/ajax/data?mid=1&tid=${encodeURIComponent(categoryId)}&page=${page}&limit=20${area ? `&area=${encodeURIComponent(area)}` : ""}${by !== "time" ? `&by=${encodeURIComponent(by)}` : ""}${clazz ? `&class=${encodeURIComponent(clazz)}` : ""}${year ? `&year=${encodeURIComponent(year)}` : ""}${lang ? `&lang=${encodeURIComponent(lang)}` : ""}`;
+    const html = await requestText(url);
+    const list = parseData(html);
     await OmniBox.log("info", `[枫叶][category] category=${categoryId} page=${page} count=${list.length}`);
     return {
       page,
@@ -499,9 +499,9 @@ async function search(params = {}) {
     const wd = normalizeText(params.wd || params.keyword || params.key || "");
     const page = Math.max(1, Number(params.page) || 1);
     if (!wd) return { list: [] };
-    const url = `${BASE_URL}/cupfox-search/${encodeURIComponent(wd)}----------${page}---.html`;
-    const html = await getCachedText(`fengye:search:${wd}:${page}`, SEARCH_CACHE_TTL, () => requestText(url));
-    const list = parseSearchList(html);
+    const url = `${BASE_URL}/index.php/ajax/suggest?mid=1&wd=${encodeURIComponent(wd)}&limit=30`;
+    const html = await requestText(url);
+    const list = parseSuggest(html);
     await OmniBox.log("info", `[枫叶][search] wd=${wd} page=${page} count=${list.length}`);
     return {
       page,
@@ -768,4 +768,50 @@ async function play(params = {}, context = {}) {
     await OmniBox.log("error", `[枫叶][play] ${e.message}`);
     return { parse: 1, url: "", urls: [], header: {}, danmaku: [] };
   }
+}
+
+
+function parseData(htmlText) {
+  try {
+    const data = JSON.parse(htmlText);
+    const arr = data && Array.isArray(data.list) ? data.list : [];
+    return arr
+      .map(function (it) {
+        return {
+          vod_id: String(it.vod_id),
+          vod_name: normalizeText(it.vod_name || ''),
+          vod_pic: fixPic(it.vod_pic || ''),
+          vod_remarks: normalizeText(it.vod_remarks || ''),
+        };
+      })
+      .filter(function (it) { return !!it.vod_id; });
+  } catch (e) {
+    return [];
+  }
+}
+
+function parseSuggest(htmlText) {
+  try {
+    const data = JSON.parse(htmlText);
+    const arr = data && Array.isArray(data.list) ? data.list : [];
+    return arr
+      .map(function (it) {
+        return {
+          vod_id: String(it.id),
+          vod_name: normalizeText(it.name || ''),
+          vod_pic: fixPic(it.pic || ''),
+          vod_remarks: normalizeText(it.remarks || ''),
+        };
+      })
+      .filter(function (it) { return !!it.vod_id; });
+  } catch (e) {
+    return [];
+  }
+}
+function fixPic(u) {
+  if (!u) return "";
+  u = String(u).replace(/&amp;/g, "&");
+  if (u.indexOf("//") === 0) return "https:" + u;
+  if (u.indexOf("/") === 0) return absoluteUrl(u);
+  return u;
 }


### PR DESCRIPTION
## 问题
budaichuchen.net 站点将 cupfox-search / cupfox-list HTML 页全部套上「系统安全验证」图形验证码，导致 search()/category() 永远返回空。

## 修复
- search(): `/cupfox-search/{wd}...` → `/index.php/ajax/suggest?mid=1&wd={wd}&limit=30`（JSON，实测搜"龙"返回 30 条）
- category(): `/cupfox-list/...` → `/index.php/ajax/data?mid=1&tid={tid}&page={page}&limit=20`（JSON，实测分类 20 条）
- 绕过 getCachedText 对旧 HTML 页的缓存；新增 parseData/parseSuggest/fixPic
- home/detail/play 不变

已在 OmniBox 容器内全链路实测：home / category / search / detail / play 均正常。